### PR TITLE
fix: repair Railway CLI deployment

### DIFF
--- a/.github/workflows/deploy_to_railway.yml
+++ b/.github/workflows/deploy_to_railway.yml
@@ -9,6 +9,7 @@ on:
       - main
       - 'release/pr-v*'
       - 'staging/**'
+      - fix/railway-cli-deploy
   workflow_dispatch:
     inputs:
       deploy-env:
@@ -23,15 +24,15 @@ on:
 
 jobs:
   deploy-to-railway:
-    if: ${{ (inputs.deploy-env || (github.ref_name == 'main' && 'Development') || (startsWith(github.ref_name, 'release/pr-v') && 'Production') || (startsWith(github.ref_name, 'staging/') && 'Staging') || 'None') != 'None' }}
+    if: ${{ (inputs.deploy-env || (github.ref_name == 'main' && 'Development') || (startsWith(github.ref_name, 'release/pr-v') && 'Production') || (startsWith(github.ref_name, 'staging/') && 'Staging') || (github.ref_name == 'fix/railway-cli-deploy' && 'Development') || 'None') != 'None' }}
     name: Deploy to Railway
     runs-on: ubuntu-latest
-    environment: ${{ inputs.deploy-env || (github.ref_name == 'main' && 'Development') || (startsWith(github.ref_name, 'release/pr-v') && 'Production') || (startsWith(github.ref_name, 'staging/') && 'Staging') || 'None' }}
+    environment: ${{ inputs.deploy-env || (github.ref_name == 'main' && 'Development') || (startsWith(github.ref_name, 'release/pr-v') && 'Production') || (startsWith(github.ref_name, 'staging/') && 'Staging') || (github.ref_name == 'fix/railway-cli-deploy' && 'Development') || 'None' }}
     env:
       RAILWAY_TOKEN: ${{ secrets.RAILWAY_GITHUB_ACTIONS }}
       RAILWAY_PROJECT_ID: 801ad5e0-95bf-4ce6-977e-6f2fa37529fd
       RAILWAY_TTY: "0"
-      TARGET_ENV: ${{ inputs.deploy-env || (github.ref_name == 'main' && 'Development') || (startsWith(github.ref_name, 'release/pr-v') && 'Production') || (startsWith(github.ref_name, 'staging/') && 'Staging') || 'None' }}
+      TARGET_ENV: ${{ inputs.deploy-env || (github.ref_name == 'main' && 'Development') || (startsWith(github.ref_name, 'release/pr-v') && 'Production') || (startsWith(github.ref_name, 'staging/') && 'Staging') || (github.ref_name == 'fix/railway-cli-deploy' && 'Development') || 'None' }}
     steps:
       - name: Print environment context
         run: |
@@ -43,9 +44,6 @@ jobs:
 
       - name: Install Railway CLI
         run: npm i -g @railway/cli
-
-      - name: Link Railway project
-        run: railway link --project "$RAILWAY_PROJECT_ID"
 
       - name: Determine deployment targets
         id: targets
@@ -84,21 +82,19 @@ jobs:
 
       - name: Deploy services
         if: steps.targets.outputs.skip != 'true'
+        env:
+          CLI_ENV: ${{ steps.targets.outputs.cli_env }}
+          SERVICES: ${{ steps.targets.outputs.services }}
         run: |
           set -euo pipefail
 
-          cli_env="${{ steps.targets.outputs.cli_env }}"
-          services="${{ steps.targets.outputs.services }}"
-
-          railway environment "$cli_env"
-
-          for svc in $services; do
+          for svc in $SERVICES; do
             if [[ "$svc" == frontend* ]]; then
               path="services/frontend"
             else
               path="services/backend"
             fi
 
-            echo "Deploying $svc from $path"
-            railway up --service "$svc" --path-as-root "$path"
+            echo "Deploying $svc from $path to $CLI_ENV"
+            railway up --ci --service "$svc" --environment "$CLI_ENV" --path-as-root "$path"
           done


### PR DESCRIPTION
## Summary
- map fix/railway-cli-deploy pushes to the Development environment so the deploy workflow runs while we iterate
- drop the interactive railway link step and deploy with --environment using the existing project token
- call railway up with --ci and per-service paths for frontend/backend

## Testing
- https://github.com/ondatra-ai/awesome-claude-mcp/actions/runs/17883988935