### PR TITLE
Fix hardcoded story in us-create template

### DIFF
--- a/scripts/bmad-cli/3.1-mcp-server-implementation.yaml
+++ b/scripts/bmad-cli/3.1-mcp-server-implementation.yaml
@@ -1,0 +1,215 @@
+story:
+  id: "3.1"
+  title: "MCP Server Implementation"
+  as_a: "Developer/Maintainer"
+  i_want: "to implement MCP protocol server"
+  so_that: "Claude can communicate with the service"
+  status: "PLANNED"
+  acceptance_criteria:
+    - id: AC-1
+      description: "WebSocket server implemented"
+    - id: AC-2
+      description: "HTTP endpoint for MCP available"
+    - id: AC-3
+      description: "Message parsing and validation"
+    - id: AC-4
+      description: "Response formatting to MCP standard"
+    - id: AC-5
+      description: "Connection management handled"
+    - id: AC-6
+      description: "Concurrent connection support"
+
+tasks:
+  - name: "Set up MCP-Go library integration and basic server structure"
+    acceptance_criteria:
+      - "AC-1"
+    subtasks:
+      - "Initialize Go module for mcp-service with Mark3Labs MCP-Go dependency"
+      - "Create cmd/main.go entry point with basic MCP server setup"
+      - "Configure MCP server with stdio transport for Claude communication"
+      - "Implement basic server initialization and graceful shutdown"
+      - "Add logging configuration using zerolog for structured JSON output"
+    status: "pending"
+
+  - name: "Implement WebSocket server for MCP protocol communication"
+    acceptance_criteria:
+      - "AC-1"
+      - "AC-5"
+      - "AC-6"
+    subtasks:
+      - "Set up WebSocket endpoint at /mcp for protocol communication"
+      - "Implement WebSocket upgrade handling with proper headers"
+      - "Add connection management with concurrent client support"
+      - "Implement heartbeat/ping-pong mechanism for connection health"
+      - "Add connection pooling and cleanup for disconnected clients"
+      - "Configure WebSocket timeouts and buffer sizes"
+    status: "pending"
+
+  - name: "Create HTTP health and version endpoints"
+    acceptance_criteria:
+      - "AC-2"
+    subtasks:
+      - "Implement /health endpoint returning service status"
+      - "Implement /version endpoint returning service version"
+      - "Add middleware for CORS, logging, and error handling"
+      - "Configure HTTP server on port 8082 (separate from WebSocket)"
+      - "Add graceful shutdown for HTTP server"
+    status: "pending"
+
+  - name: "Implement MCP message parsing and validation"
+    acceptance_criteria:
+      - "AC-3"
+    subtasks:
+      - "Create MCP message structs following protocol specification"
+      - "Implement JSON-RPC message parsing for MCP requests"
+      - "Add request validation using schema validation"
+      - "Create error response formatting for invalid messages"
+      - "Implement message ID tracking for request-response correlation"
+      - "Add input sanitization for all message fields"
+    status: "pending"
+
+  - name: "Build MCP response formatting to protocol standard"
+    acceptance_criteria:
+      - "AC-4"
+    subtasks:
+      - "Create response message structs following MCP protocol"
+      - "Implement JSON-RPC response formatting"
+      - "Add error response handling with proper error codes"
+      - "Create success response formatting with result data"
+      - "Implement tool registration response formatting"
+      - "Add capability announcement response handling"
+    status: "pending"
+
+  - name: "Implement tool registration and discovery system"
+    acceptance_criteria:
+      - "AC-1"
+      - "AC-3"
+    subtasks:
+      - "Register document editing tools (replace_all, append, prepend, etc.)"
+      - "Define tool schemas with parameter validation"
+      - "Implement tool discovery endpoint for Claude"
+      - "Add tool capability announcements"
+      - "Create tool execution routing and dispatch"
+      - "Add tool result formatting and error handling"
+    status: "pending"
+
+  - name: "Create configuration management and environment setup"
+    acceptance_criteria:
+      - "AC-1"
+      - "AC-2"
+    subtasks:
+      - "Set up Viper configuration management"
+      - "Define environment variables for MCP service"
+      - "Create configuration struct with server, auth, and logging settings"
+      - "Add configuration validation and defaults"
+      - "Implement environment-specific configuration loading"
+      - "Add Railway deployment environment configuration"
+    status: "pending"
+
+  - name: "Implement unit tests for MCP server components"
+    acceptance_criteria:
+      - "AC-1"
+      - "AC-3"
+      - "AC-4"
+    subtasks:
+      - "Create unit tests for MCP message parsing using testify"
+      - "Add tests for WebSocket connection handling"
+      - "Test tool registration and discovery functionality"
+      - "Create mock Claude client for testing tool execution"
+      - "Add tests for configuration loading and validation"
+      - "Achieve 85% code coverage for business logic"
+    status: "pending"
+
+  - name: "Add integration tests for MCP protocol compliance"
+    acceptance_criteria:
+      - "AC-1"
+      - "AC-3"
+      - "AC-4"
+      - "AC-5"
+    subtasks:
+      - "Create integration tests with real WebSocket connections"
+      - "Test complete MCP handshake and tool discovery flow"
+      - "Verify protocol compliance with MCP specification"
+      - "Test concurrent connection handling"
+      - "Add end-to-end tests simulating Claude client interactions"
+      - "Test error scenarios and recovery mechanisms"
+    status: "pending"
+
+  - name: "Set up Docker containerization and Railway deployment"
+    acceptance_criteria:
+      - "AC-1"
+      - "AC-2"
+    subtasks:
+      - "Create multi-stage Dockerfile for mcp-service"
+      - "Configure Railway service definition in railway.toml"
+      - "Set up environment variables in Railway dashboard"
+      - "Add health check endpoint for Railway monitoring"
+      - "Configure service port mapping for WebSocket and HTTP"
+      - "Test deployment to Railway development environment"
+    status: "pending"
+
+dev_notes:
+  previous_story_insights: "This is a new story without previous implementation insights"
+
+  technology_stack:
+    language: "Go"
+    framework: "Standard library"
+    mcp_integration: "MCP integration as needed"
+    logging: "slog"
+    config: "viper"
+
+  architecture:
+    component: "MCP Server Implementation"
+    responsibilities:
+      - "Implement core functionality"
+      - "Handle business logic"
+    dependencies:
+      - "context"
+      - "fmt"
+      - "log/slog"
+    tech_stack:
+      - "Go"
+      - "YAML"
+      - "HTTP"
+      - "JSON"
+
+  file_structure:
+    files:
+      - "services/backend/internal/story/implementation.go"
+
+  configuration:
+    environment_variables:
+      LOG_LEVEL: "info"
+      PORT: "8080"
+      TEMPLATE_PATH: "templates/"
+
+  performance_requirements:
+    connection_establishment: "< 100ms"
+    message_processing: "< 50ms"
+    concurrent_connections: "100"
+    memory_usage: "< 100MB"
+
+testing:
+  test_location: "services/backend/tests"
+  frameworks:
+    - "testing"
+    - "testify"
+  requirements:
+    - "Unit tests for all public methods"
+    - "Integration tests for external dependencies"
+    - "End-to-end tests for complete workflows"
+  coverage:
+    business_logic: "80%"
+    overall: "75%"
+
+change_log:
+  - date: "2025-09-26"
+    version: "1.0.0"
+    description: "Initial story creation"
+    author: "bmad-cli"
+
+dev_agent_record:
+  agent_model_used: null
+  debug_log_references: []
+  completion_notes: []
+  file_list: []

--- a/scripts/bmad-cli/3.2-tool-registration.yaml
+++ b/scripts/bmad-cli/3.2-tool-registration.yaml
@@ -1,0 +1,159 @@
+story:
+  id: "3.2"
+  title: "Tool Registration"
+  as_a: "Claude User"
+  i_want: "to discover available tools"
+  so_that: "I know what operations are available"
+  status: "PLANNED"
+  acceptance_criteria:
+    - id: AC-1
+      description: "Tool definition schema created"
+    - id: AC-2
+      description: "Tool registration endpoint working"
+    - id: AC-3
+      description: "Tool capabilities described clearly"
+    - id: AC-4
+      description: "Parameter schemas defined"
+    - id: AC-5
+      description: "Version information included"
+    - id: AC-6
+      description: "Dynamic or static registration (TBD after testing)"
+
+tasks:
+  - name: "Implement tool schema definition with parameter validation"
+    acceptance_criteria:
+      - "AC-1"
+    subtasks:
+      - "Create structured schema definitions for all six document operations in internal/mcp/tools/"
+      - "Define parameter schemas for replace_all, append, prepend, replace_match, insert_before, insert_after operations"
+      - "Implement validation for required fields (documentId, content, anchor for positioned operations)"
+      - "Add enum constraints for operation types and case sensitivity options"
+      - "Include format patterns for Google Docs document IDs"
+      - "Create JSON schemas following MCP protocol standards"
+    status: "pending"
+
+  - name: "Develop tool registration endpoint with MCP compliance"
+    acceptance_criteria:
+      - "AC-2"
+    subtasks:
+      - "Implement MCP protocol handshake and capability negotiation in internal/server/mcp.go"
+      - "Create tool discovery endpoint returning available operations"
+      - "Register all six document operations with their schemas"
+      - "Handle MCP client tool requests with proper JSON-RPC responses"
+      - "Implement error handling for unsupported tool requests"
+      - "Add logging for tool registration events"
+    status: "pending"
+
+  - name: "Create comprehensive tool capabilities documentation"
+    acceptance_criteria:
+      - "AC-3"
+    subtasks:
+      - "Generate clear descriptions for each document operation tool"
+      - "Document operation types: replace_all, append, prepend, replace_match, insert_before, insert_after"
+      - "Specify required vs optional parameters for each operation"
+      - "Include usage examples and expected outcomes"
+      - "Document error scenarios and recovery suggestions"
+      - "Create user-facing help text for Claude AI integration"
+    status: "pending"
+
+  - name: "Define comprehensive parameter schemas with validation"
+    acceptance_criteria:
+      - "AC-4"
+    subtasks:
+      - "Implement structured parameter definitions in pkg/types/tools.go"
+      - "Create validation rules for documentId format (Google Docs ID pattern)"
+      - "Define content validation (Markdown format, size limits)"
+      - "Add anchor text validation for positioned operations"
+      - "Implement case sensitivity parameter validation"
+      - "Create parameter type definitions with MCP-compatible JSON schemas"
+    status: "pending"
+
+  - name: "Include version information in tool registration"
+    acceptance_criteria:
+      - "AC-5"
+    subtasks:
+      - "Add version field to MCP server configuration"
+      - "Include version in tool registration responses"
+      - "Implement version compatibility checking"
+      - "Add version to health check and status endpoints"
+      - "Create version metadata for tool definitions"
+      - "Document version update procedures"
+    status: "pending"
+
+  - name: "Implement static tool registration for initial deployment"
+    acceptance_criteria:
+      - "AC-6"
+    subtasks:
+      - "Configure static tool registration in server startup"
+      - "Pre-register all six document operations on server initialization"
+      - "Implement static tool discovery responses"
+      - "Add configuration for enabling/disabling specific tools"
+      - "Create static tool metadata cache"
+      - "Prepare infrastructure for future dynamic registration upgrade"
+    status: "pending"
+
+dev_notes:
+  previous_story_insights: "This is a new story without previous implementation insights"
+
+  technology_stack:
+    language: "Go"
+    framework: "Standard library"
+    mcp_integration: "MCP integration as needed"
+    logging: "slog"
+    config: "viper"
+
+  architecture:
+    component: "Tool Registration"
+    responsibilities:
+      - "Implement core functionality"
+      - "Handle business logic"
+    dependencies:
+      - "context"
+      - "fmt"
+      - "log/slog"
+    tech_stack:
+      - "Go"
+      - "YAML"
+      - "HTTP"
+      - "JSON"
+
+  file_structure:
+    files:
+      - "services/backend/internal/story/implementation.go"
+
+  configuration:
+    environment_variables:
+      LOG_LEVEL: "info"
+      PORT: "8080"
+      TEMPLATE_PATH: "templates/"
+
+  performance_requirements:
+    connection_establishment: "< 100ms"
+    message_processing: "< 50ms"
+    concurrent_connections: "100"
+    memory_usage: "< 100MB"
+
+testing:
+  test_location: "services/backend/tests"
+  frameworks:
+    - "testing"
+    - "testify"
+  requirements:
+    - "Unit tests for all public methods"
+    - "Integration tests for external dependencies"
+    - "End-to-end tests for complete workflows"
+  coverage:
+    business_logic: "80%"
+    overall: "75%"
+
+change_log:
+  - date: "2025-09-26"
+    version: "1.0.0"
+    description: "Initial story creation"
+    author: "bmad-cli"
+
+dev_agent_record:
+  agent_model_used: null
+  debug_log_references: []
+  completion_notes: []
+  file_list: []

--- a/scripts/bmad-cli/internal/domain/services/task_generator.go
+++ b/scripts/bmad-cli/internal/domain/services/task_generator.go
@@ -54,7 +54,7 @@ func (g *AITaskGenerator) GenerateTasks(ctx context.Context, story *story.Story,
 	}
 
 	// Write full AI response to file for debugging
-	responseFile := "./tmp/3.1-full-response.txt"
+	responseFile := fmt.Sprintf("./tmp/%s-full-response.txt", story.ID)
 	if err := os.WriteFile(responseFile, []byte(response), 0644); err != nil {
 		return nil, fmt.Errorf("failed to write response file: %w", err)
 	}
@@ -65,7 +65,7 @@ func (g *AITaskGenerator) GenerateTasks(ctx context.Context, story *story.Story,
 	if err != nil {
 		// If parsing fails, let's save the extracted YAML block for debugging
 		yamlBlock := g.extractYAMLBlock(response)
-		yamlFile := "./tmp/3.1-extracted-yaml.yml"
+		yamlFile := fmt.Sprintf("./tmp/%s-extracted-yaml.yml", story.ID)
 		if yamlBlock != "" {
 			if err := os.WriteFile(yamlFile, []byte(yamlBlock), 0644); err == nil {
 				fmt.Printf("💾 Extracted YAML block saved to: %s\n", yamlFile)
@@ -77,7 +77,7 @@ func (g *AITaskGenerator) GenerateTasks(ctx context.Context, story *story.Story,
 	// Save successfully parsed tasks to YAML file
 	taskMap := map[string]interface{}{"tasks": tasks}
 	if tasksYAML, yamlErr := yaml.Marshal(taskMap); yamlErr == nil {
-		tasksFile := "./tmp/3.1-tasks.yml"
+		tasksFile := fmt.Sprintf("./tmp/%s-tasks.yml", story.ID)
 		if writeErr := os.WriteFile(tasksFile, tasksYAML, 0644); writeErr == nil {
 			fmt.Printf("✅ Parsed tasks saved to: %s\n", tasksFile)
 		}

--- a/scripts/bmad-cli/internal/infrastructure/template/task_prompt_loader.go
+++ b/scripts/bmad-cli/internal/infrastructure/template/task_prompt_loader.go
@@ -79,8 +79,8 @@ func (l *TaskPromptLoader) convertStoryToYAML(story *story.Story) (string, error
 func (l *TaskPromptLoader) injectTemplateData(template, storyYAML string, architectureDocs map[string]string) string {
 	result := template
 
-	// Replace the story YAML block (find and replace the existing story block in template)
-	result = l.replaceStoryBlock(result, storyYAML)
+	// Replace the story YAML placeholder
+	result = strings.ReplaceAll(result, "{{.StoryYAML}}", storyYAML)
 
 	// Replace architecture document placeholders
 	for key, content := range architectureDocs {
@@ -103,49 +103,4 @@ func (l *TaskPromptLoader) injectTemplateData(template, storyYAML string, archit
 	}
 
 	return result
-}
-
-// replaceStoryBlock replaces the existing story block in the template with the new story YAML
-func (l *TaskPromptLoader) replaceStoryBlock(template, newStoryYAML string) string {
-	// Find the story block between ```yaml and ``` that contains the story
-	lines := strings.Split(template, "\n")
-	var result []string
-	inStoryBlock := false
-	storyBlockFound := false
-
-	for i, line := range lines {
-		if strings.Contains(line, "```yaml") && !storyBlockFound {
-			// Check if this yaml block contains a story by looking ahead
-			if l.isStoryBlock(lines, i) {
-				inStoryBlock = true
-				storyBlockFound = true
-				result = append(result, line)
-				result = append(result, strings.Split(newStoryYAML, "\n")...)
-				continue
-			}
-		}
-
-		if inStoryBlock && strings.TrimSpace(line) == "```" {
-			inStoryBlock = false
-			result = append(result, line)
-			continue
-		}
-
-		if !inStoryBlock {
-			result = append(result, line)
-		}
-	}
-
-	return strings.Join(result, "\n")
-}
-
-// isStoryBlock checks if a YAML block starting at the given index contains a story
-func (l *TaskPromptLoader) isStoryBlock(lines []string, startIndex int) bool {
-	// Look ahead in the YAML block for story-related content
-	for i := startIndex + 1; i < len(lines) && !strings.HasPrefix(strings.TrimSpace(lines[i]), "```"); i++ {
-		if strings.Contains(lines[i], "story:") || strings.Contains(lines[i], "id:") || strings.Contains(lines[i], "title:") {
-			return true
-		}
-	}
-	return false
 }

--- a/scripts/bmad-cli/templates/us-create.tasks.prompt.tpl
+++ b/scripts/bmad-cli/templates/us-create.tasks.prompt.tpl
@@ -86,26 +86,7 @@ REMINDER: Output ONLY the YAML block with tasks. No explanatory text before or a
 
 ## User Story
 ```yaml
-story:
-  id: "3.1"
-  title: "MCP Server Implementation"
-  status: "Draft"
-  as_a: "Developer/Maintainer"
-  i_want: "to implement MCP protocol server"
-  so_that: "Claude can communicate with the service"
-  acceptance_criteria:
-    - id: AC-1
-      description: "WebSocket server implemented"
-    - id: AC-2
-      description: "HTTP endpoint for MCP available"
-    - id: AC-3
-      description: "Message parsing and validation"
-    - id: AC-4
-      description: "Response formatting to MCP standard"
-    - id: AC-5
-      description: "Connection management handled"
-    - id: AC-6
-      description: "Concurrent connection support"
+{{.StoryYAML}}
 ```
 
 {{.Architecture}}


### PR DESCRIPTION
## Summary
- Removed hardcoded Story 3.1 data from template
- Added dynamic story placeholder injection
- Fixed debug file naming issue

## Changes
- Updated `us-create.tasks.prompt.tpl` to use placeholder
- Modified `TaskPromptLoader` for cleaner injection
- Fixed debug file naming in `task_generator.go`

## Testing
- Tested with stories 3.1 and 3.2
- Verified correct story injection
- Confirmed separate debug files per story

🤖 Generated with [Claude Code](https://claude.ai/code)