### PR TITLE
Fix DevNotes not populating in us-create command

### DIFF
--- a/scripts/bmad-cli/internal/domain/services/story_factory.go
+++ b/scripts/bmad-cli/internal/domain/services/story_factory.go
@@ -19,7 +19,7 @@ type TaskGenerator interface {
 
 // DevNotesGenerator interface for generating dev notes
 type DevNotesGenerator interface {
-	GenerateDevNotes(ctx context.Context, story *story.Story, tasks []story.Task, architectureDocs map[string]docs.ArchitectureDoc) (*story.DevNotes, error)
+	GenerateDevNotes(ctx context.Context, story *story.Story, tasks []story.Task, architectureDocs map[string]docs.ArchitectureDoc) (story.DevNotes, error)
 }
 
 // ArchitectureLoader interface for loading architecture documents
@@ -65,7 +65,7 @@ func (f *StoryFactory) CreateStory(ctx context.Context, storyNumber string) (*st
 	return &story.StoryDocument{
 		Story:    *loadedStory,
 		Tasks:    tasks,
-		DevNotes: *devNotes,
+		DevNotes: devNotes,
 		Testing: story.Testing{
 			TestLocation: "services/backend/tests",
 			Frameworks:   []string{"testing", "testify"},
@@ -125,7 +125,7 @@ func (f *StoryFactory) generateTasks(ctx context.Context, loadedStory *story.Sto
 }
 
 // generateDevNotes generates dev_notes using AI - fails on any error
-func (f *StoryFactory) generateDevNotes(ctx context.Context, loadedStory *story.Story, tasks []story.Task) (*story.DevNotes, error) {
+func (f *StoryFactory) generateDevNotes(ctx context.Context, loadedStory *story.Story, tasks []story.Task) (story.DevNotes, error) {
 
 	// Load architecture documents - fail immediately if any are missing
 	architectureDocs, err := f.architectureLoader.LoadAllArchitectureDocs()
@@ -136,7 +136,7 @@ func (f *StoryFactory) generateDevNotes(ctx context.Context, loadedStory *story.
 	// Generate dev_notes using AI - fail if AI generation fails
 	devNotes, err := f.devNotesGenerator.GenerateDevNotes(ctx, loadedStory, tasks, architectureDocs)
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate dev_notes using AI: %w", err)
+		return story.DevNotes{}, fmt.Errorf("failed to generate dev_notes using AI: %w", err)
 	}
 
 	fmt.Printf("✅ Generated dev_notes using AI\n")


### PR DESCRIPTION
## Summary
Fix the issue where dev_notes were not populating in the final YAML output when running `bmad-cli sm us-create`.

## Root Cause
The `CreateYAMLFileParser` generic function was incorrectly handling `*DevNotesType` (pointer to map). When `T` was `*map[string]interface{}`, the function created `map[string]*map[string]interface{}`, causing incorrect YAML unmarshaling.

## Solution
- Updated `dev_notes_generator.go` to return `DevNotesType` instead of `*DevNotesType`
- Updated `story_factory.go` interface and implementation accordingly  
- Aligned DevNotes handling with Tasks pattern (which works correctly)

## Changes
- `GenerateDevNotes()` now returns `DevNotesType` instead of `*DevNotesType`
- YAML parser now uses `DevNotesType` directly, not a pointer
- All function signatures updated consistently

## Test Results
- ✅ Code compiles without errors
- ✅ DevNotes are generated correctly by AI and saved to tmp files
- ⚠️ Still investigating template processing issue

🤖 Generated with [Claude Code](https://claude.ai/code)