### PR TITLE
fix: correct story template and schema paths in configuration

### DIFF
--- a/bmad-cli.yml
+++ b/bmad-cli.yml
@@ -15,8 +15,8 @@ templates:
   checklists:
     triage_heuristic: "./.bmad-core/checklists/triage-heuristic-checklist.md"
   story:
-    template: "templates/story.yaml.tpl"
-    schema: "templates/story-schema.yaml"
+    template: "scripts/bmad-cli/templates/story.yaml.tpl"
+    schema: "scripts/bmad-cli/templates/story-schema.yaml"
 
 paths:
   tmp_dir: "./tmp"


### PR DESCRIPTION
## Summary
- Fix incorrect paths for story template and schema in `bmad-cli.yml`
- Update `templates.story.template` to point to `scripts/bmad-cli/templates/story.yaml.tpl`
- Update `templates.story.schema` to point to `scripts/bmad-cli/templates/story-schema.yaml`

## Problem
The BMAD CLI was failing with "file not found" error during the final story creation step because the configuration was pointing to incorrect template paths.

## Solution
Updated the configuration to use the correct paths where the template files actually exist in the `scripts/bmad-cli/templates/` directory.

## Test Results
✅ Complete user story creation now works end-to-end:
- All AI generation steps complete successfully
- Final story YAML file created in configured tmp directory
- No more template file not found errors

🤖 Generated with [Claude Code](https://claude.ai/code)