### PR TITLE
refactor: simplify BMAD CLI command structure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ Since this is a new repository without code, common setup tasks will depend on t
 
 ### BMAD CLI Usage
 **CRITICAL**: Always run BMAD CLI from the repository root directory, not from `scripts/bmad-cli/`
-- Build and run: `go build -C scripts/bmad-cli -o ./bmad-cli && timeout 600 scripts/bmad-cli/bmad-cli sm us-create 3.1`
+- Build and run: `go build -C scripts/bmad-cli -o ./bmad-cli && timeout 600 scripts/bmad-cli/bmad-cli us create 3.1`
 - Use 10-minute timeout (600 seconds) for story generation commands that involve AI processing
 - This ensures proper path resolution for config files and tmp directories
 

--- a/scripts/bmad-cli/cmd/pr.go
+++ b/scripts/bmad-cli/cmd/pr.go
@@ -11,14 +11,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NewDevCommand(container *app.Container) *cobra.Command {
-	devCmd := &cobra.Command{
-		Use:   "dev",
-		Short: "Developer persona",
+func NewPRCommand(container *app.Container) *cobra.Command {
+	prCmd := &cobra.Command{
+		Use:   "pr",
+		Short: "Pull request commands",
 	}
 
-	prTriageCmd := &cobra.Command{
-		Use:   "pr-triage",
+	triageCmd := &cobra.Command{
+		Use:   "triage",
 		Short: "Run PR triage",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, stop := signal.NotifyContext(context.Background(),
@@ -26,7 +26,7 @@ func NewDevCommand(container *app.Container) *cobra.Command {
 			defer stop()
 
 			engineType := container.Config.GetString("engine.type")
-			fmt.Fprintf(os.Stderr, "bmad-cli dev pr-triage engine: %s\n", engineType)
+			fmt.Fprintf(os.Stderr, "bmad-cli pr triage engine: %s\n", engineType)
 
 			err := container.PRTriageCmd.Execute(ctx)
 
@@ -40,6 +40,6 @@ func NewDevCommand(container *app.Container) *cobra.Command {
 		},
 	}
 
-	devCmd.AddCommand(prTriageCmd)
-	return devCmd
+	prCmd.AddCommand(triageCmd)
+	return prCmd
 }

--- a/scripts/bmad-cli/cmd/root.go
+++ b/scripts/bmad-cli/cmd/root.go
@@ -19,8 +19,8 @@ func Execute() {
 		Short: "BMAD CLI tool",
 	}
 
-	rootCmd.AddCommand(NewDevCommand(container))
-	rootCmd.AddCommand(NewSMCommand(container))
+	rootCmd.AddCommand(NewPRCommand(container))
+	rootCmd.AddCommand(NewUSCommand(container))
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)

--- a/scripts/bmad-cli/cmd/us.go
+++ b/scripts/bmad-cli/cmd/us.go
@@ -10,14 +10,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NewSMCommand(container *app.Container) *cobra.Command {
-	smCmd := &cobra.Command{
-		Use:   "sm",
-		Short: "Story management",
+func NewUSCommand(container *app.Container) *cobra.Command {
+	usCmd := &cobra.Command{
+		Use:   "us",
+		Short: "User story commands",
 	}
 
-	usCreateCmd := &cobra.Command{
-		Use:   "us-create [story-number]",
+	createCmd := &cobra.Command{
+		Use:   "create [story-number]",
 		Short: "Create user story",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -33,6 +33,6 @@ func NewSMCommand(container *app.Container) *cobra.Command {
 		},
 	}
 
-	smCmd.AddCommand(usCreateCmd)
-	return smCmd
+	usCmd.AddCommand(createCmd)
+	return usCmd
 }


### PR DESCRIPTION
## Summary
Simplify BMAD CLI command structure by removing unnecessary parent commands for better UX.

**Before:**
- `bmad-cli sm us-create [story-number]`
- `bmad-cli dev pr-triage`

**After:**
- `bmad-cli us create [story-number]`
- `bmad-cli pr triage`

## Changes
- Rename `cmd/sm.go` → `cmd/us.go` with refactored command structure
- Rename `cmd/dev.go` → `cmd/pr.go` with refactored command structure
- Update `cmd/root.go` to use new command functions
- Update `CLAUDE.md` documentation with new syntax

## Testing
- ✅ Built successfully with `go build -C scripts/bmad-cli`
- ✅ Verified help output shows new structure
- ✅ All pre-commit hooks passed

## Impact
- Zero breaking changes to internal command implementations
- Only affects CLI interface routing
- More intuitive command structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)