### PR TITLE
feat: add bmad-cli us implement placeholder command

### DIFF
--- a/scripts/bmad-cli/cmd/us.go
+++ b/scripts/bmad-cli/cmd/us.go
@@ -33,6 +33,24 @@ func NewUSCommand(container *app.Container) *cobra.Command {
 		},
 	}
 
+	implementCmd := &cobra.Command{
+		Use:   "implement [story-number]",
+		Short: "Implement user story (placeholder)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, stop := signal.NotifyContext(context.Background(),
+				os.Interrupt, syscall.SIGTERM)
+			defer stop()
+
+			err := container.USImplementCmd.Execute(ctx, args[0])
+
+			stop()
+
+			return err
+		},
+	}
+
 	usCmd.AddCommand(createCmd)
+	usCmd.AddCommand(implementCmd)
 	return usCmd
 }

--- a/scripts/bmad-cli/internal/app/container.go
+++ b/scripts/bmad-cli/internal/app/container.go
@@ -21,9 +21,10 @@ import (
 )
 
 type Container struct {
-	Config      *config.ViperConfig
-	PRTriageCmd *commands.PRTriageCommand
-	USCreateCmd *commands.USCreateCommand
+	Config         *config.ViperConfig
+	PRTriageCmd    *commands.PRTriageCommand
+	USCreateCmd    *commands.USCreateCommand
+	USImplementCmd *commands.USImplementCommand
 }
 
 func NewContainer() (*Container, error) {
@@ -56,10 +57,14 @@ func NewContainer() (*Container, error) {
 	// Setup PR triage command - required for operation
 	prTriageCmd := createPRTriageCommand(githubService, claudeClient, cfg)
 
+	// Setup user story implement command - placeholder for future implementation
+	usImplementCmd := commands.NewUSImplementCommand()
+
 	return &Container{
-		Config:      cfg,
-		PRTriageCmd: prTriageCmd,
-		USCreateCmd: usCreateCmd,
+		Config:         cfg,
+		PRTriageCmd:    prTriageCmd,
+		USCreateCmd:    usCreateCmd,
+		USImplementCmd: usImplementCmd,
 	}, nil
 }
 

--- a/scripts/bmad-cli/internal/application/commands/us_implement_command.go
+++ b/scripts/bmad-cli/internal/application/commands/us_implement_command.go
@@ -1,0 +1,18 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+)
+
+type USImplementCommand struct{}
+
+func NewUSImplementCommand() *USImplementCommand {
+	return &USImplementCommand{}
+}
+
+func (c *USImplementCommand) Execute(ctx context.Context, storyNumber string) error {
+	fmt.Printf("bmad-cli us implement called with story: %s\n", storyNumber)
+	fmt.Println("Implementation not yet available - placeholder command")
+	return nil
+}


### PR DESCRIPTION
## Summary
Add placeholder command structure for `bmad-cli us implement` to prepare for future story implementation automation.

## Changes
- **New file**: `us_implement_command.go` - placeholder command that outputs message and exits
- **Updated**: `container.go` - wire USImplementCmd into dependency container
- **Updated**: `us.go` - add `implement` subcommand to us command group

## Command Usage
```bash
bmad-cli us implement 3.1
```

**Output:**
```
bmad-cli us implement called with story: 3.1
Implementation not yet available - placeholder command
```

## Testing
- ✅ Built successfully with `go build -C scripts/bmad-cli`
- ✅ Command executes and returns exit 0
- ✅ Help text shows new subcommand
- ✅ All pre-commit hooks passed

## Purpose
Establishes command structure for future implementation of automated story task execution with AI assistance. This is a minimal placeholder that can be expanded later with:
- Story YAML loading
- Task execution with Claude Code client
- Progress tracking and status updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)