### PR TITLE
refactor: fix critical architecture inconsistencies in BMAD CLI

### DIFF
--- a/scripts/bmad-cli/internal/adapters/github/service.go
+++ b/scripts/bmad-cli/internal/adapters/github/service.go
@@ -7,30 +7,32 @@ import (
 	"bmad-cli/internal/infrastructure/shell"
 )
 
-type GitHubPort struct {
+// GitHubService implements the GitHubPort interface (Hexagonal Architecture adapter)
+// This is the implementation/adapter, not the port interface
+type GitHubService struct {
 	prFetcher      *PRNumberFetcher
 	threadsFetcher *ThreadsFetcher
 	threadResolver *ThreadResolver
 }
 
-func NewGitHubPort(shell *shell.CommandRunner) *GitHubPort {
+func NewGitHubService(shell *shell.CommandRunner) *GitHubService {
 	client := NewGitHubCLIClient(shell)
 
-	return &GitHubPort{
+	return &GitHubService{
 		prFetcher:      NewPRNumberFetcher(client),
 		threadsFetcher: NewThreadsFetcher(client),
 		threadResolver: NewThreadResolver(client),
 	}
 }
 
-func (s *GitHubPort) GetPRNumber(ctx context.Context) (int, error) {
+func (s *GitHubService) GetPRNumber(ctx context.Context) (int, error) {
 	return s.prFetcher.Fetch(ctx)
 }
 
-func (s *GitHubPort) FetchThreads(ctx context.Context, prNumber int) ([]models.Thread, error) {
+func (s *GitHubService) FetchThreads(ctx context.Context, prNumber int) ([]models.Thread, error) {
 	return s.threadsFetcher.FetchAll(ctx, prNumber)
 }
 
-func (s *GitHubPort) ResolveThread(ctx context.Context, threadID, message string) error {
+func (s *GitHubService) ResolveThread(ctx context.Context, threadID, message string) error {
 	return s.threadResolver.Resolve(ctx, threadID, message)
 }

--- a/scripts/bmad-cli/internal/adapters/github/service.go
+++ b/scripts/bmad-cli/internal/adapters/github/service.go
@@ -7,30 +7,30 @@ import (
 	"bmad-cli/internal/infrastructure/shell"
 )
 
-type GitHubService struct {
+type GitHubPort struct {
 	prFetcher      *PRNumberFetcher
 	threadsFetcher *ThreadsFetcher
 	threadResolver *ThreadResolver
 }
 
-func NewGitHubService(shell *shell.CommandRunner) *GitHubService {
+func NewGitHubPort(shell *shell.CommandRunner) *GitHubPort {
 	client := NewGitHubCLIClient(shell)
 
-	return &GitHubService{
+	return &GitHubPort{
 		prFetcher:      NewPRNumberFetcher(client),
 		threadsFetcher: NewThreadsFetcher(client),
 		threadResolver: NewThreadResolver(client),
 	}
 }
 
-func (s *GitHubService) GetPRNumber(ctx context.Context) (int, error) {
+func (s *GitHubPort) GetPRNumber(ctx context.Context) (int, error) {
 	return s.prFetcher.Fetch(ctx)
 }
 
-func (s *GitHubService) FetchThreads(ctx context.Context, prNumber int) ([]models.Thread, error) {
+func (s *GitHubPort) FetchThreads(ctx context.Context, prNumber int) ([]models.Thread, error) {
 	return s.threadsFetcher.FetchAll(ctx, prNumber)
 }
 
-func (s *GitHubService) ResolveThread(ctx context.Context, threadID, message string) error {
+func (s *GitHubPort) ResolveThread(ctx context.Context, threadID, message string) error {
 	return s.threadResolver.Resolve(ctx, threadID, message)
 }

--- a/scripts/bmad-cli/internal/app/container.go
+++ b/scripts/bmad-cli/internal/app/container.go
@@ -39,7 +39,7 @@ func NewContainer() (*Container, error) {
 
 	shellExec := shell.NewCommandRunner()
 
-	githubService := github.NewGitHubService(shellExec)
+	githubService := github.NewGitHubPort(shellExec)
 
 	// Setup user story creation dependencies
 	epicLoader := epic.NewEpicLoader(cfg)
@@ -80,7 +80,7 @@ func createUSCreateCommand(epicLoader *epic.EpicLoader, claudeClient *ai.ClaudeC
 	return commands.NewUSCreateCommand(storyFactory, storyTemplateLoader, yamaleValidator)
 }
 
-func createPRTriageCommand(githubService *github.GitHubService, claudeClient *ai.ClaudeClient, cfg *config.ViperConfig) *commands.PRTriageCommand {
+func createPRTriageCommand(githubService *github.GitHubPort, claudeClient *ai.ClaudeClient, cfg *config.ViperConfig) *commands.PRTriageCommand {
 	// Create prompt dependencies
 	templateEngine := prompt_builders.NewTemplateEngine()
 	yamlParser := prompt_builders.NewYAMLParser()

--- a/scripts/bmad-cli/internal/app/container.go
+++ b/scripts/bmad-cli/internal/app/container.go
@@ -39,7 +39,7 @@ func NewContainer() (*Container, error) {
 
 	shellExec := shell.NewCommandRunner()
 
-	githubService := github.NewGitHubPort(shellExec)
+	githubService := github.NewGitHubService(shellExec)
 
 	// Setup user story creation dependencies
 	epicLoader := epic.NewEpicLoader(cfg)
@@ -80,7 +80,7 @@ func createUSCreateCommand(epicLoader *epic.EpicLoader, claudeClient *ai.ClaudeC
 	return commands.NewUSCreateCommand(storyFactory, storyTemplateLoader, yamaleValidator)
 }
 
-func createPRTriageCommand(githubService *github.GitHubPort, claudeClient *ai.ClaudeClient, cfg *config.ViperConfig) *commands.PRTriageCommand {
+func createPRTriageCommand(githubService *github.GitHubService, claudeClient *ai.ClaudeClient, cfg *config.ViperConfig) *commands.PRTriageCommand {
 	// Create prompt dependencies
 	templateEngine := prompt_builders.NewTemplateEngine()
 	yamlParser := prompt_builders.NewYAMLParser()

--- a/scripts/bmad-cli/internal/application/commands/pr_triage_command.go
+++ b/scripts/bmad-cli/internal/application/commands/pr_triage_command.go
@@ -16,13 +16,13 @@ import (
 const lowRiskThreshold = 5
 
 type PRTriageCommand struct {
-	github          ports.GitHubService
+	github          ports.GitHubPort
 	threadProcessor *ai.ThreadProcessor
 	config          *config.ViperConfig
 }
 
 func NewPRTriageCommand(
-	github ports.GitHubService,
+	github ports.GitHubPort,
 	threadProcessor *ai.ThreadProcessor,
 	config *config.ViperConfig,
 ) *PRTriageCommand {

--- a/scripts/bmad-cli/internal/common/ai/generator.go
+++ b/scripts/bmad-cli/internal/common/ai/generator.go
@@ -1,4 +1,4 @@
-package services
+package ai
 
 import (
 	"context"
@@ -13,6 +13,7 @@ import (
 )
 
 // AIClient defines the interface for AI communication
+// Note: This duplicates the interface from domain/services for package independence
 type AIClient interface {
 	ExecutePromptWithSystem(ctx context.Context, systemPrompt string, userPrompt string, model string, mode ai.ExecutionMode) (string, error)
 }

--- a/scripts/bmad-cli/internal/domain/models/epic.go
+++ b/scripts/bmad-cli/internal/domain/models/epic.go
@@ -1,4 +1,4 @@
-package epic
+package models
 
 import "bmad-cli/internal/domain/models/story"
 

--- a/scripts/bmad-cli/internal/domain/ports/github_port.go
+++ b/scripts/bmad-cli/internal/domain/ports/github_port.go
@@ -6,7 +6,9 @@ import (
 	"bmad-cli/internal/domain/models"
 )
 
-type GitHubService interface {
+// GitHubPort defines the port interface for GitHub operations
+// Following Hexagonal Architecture, ports define contracts for external adapters
+type GitHubPort interface {
 	GetPRNumber(ctx context.Context) (int, error)
 	FetchThreads(ctx context.Context, prNumber int) ([]models.Thread, error)
 	ResolveThread(ctx context.Context, threadID, message string) error

--- a/scripts/bmad-cli/internal/domain/services/ai_client.go
+++ b/scripts/bmad-cli/internal/domain/services/ai_client.go
@@ -1,0 +1,13 @@
+package services
+
+import (
+	"context"
+
+	"bmad-cli/internal/adapters/ai"
+)
+
+// AIClient defines the interface for AI communication
+// This interface belongs in domain/services as it represents a domain service contract
+type AIClient interface {
+	ExecutePromptWithSystem(ctx context.Context, systemPrompt string, userPrompt string, model string, mode ai.ExecutionMode) (string, error)
+}

--- a/scripts/bmad-cli/internal/domain/services/dev_notes_generator.go
+++ b/scripts/bmad-cli/internal/domain/services/dev_notes_generator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"bmad-cli/internal/common/ai"
 	"bmad-cli/internal/domain/models/story"
 	"bmad-cli/internal/infrastructure/config"
 	"bmad-cli/internal/infrastructure/docs"
@@ -33,7 +34,7 @@ func NewDevNotesGenerator(aiClient AIClient, config *config.ViperConfig) *AIDevN
 
 // GenerateDevNotes generates story dev_notes using AI based on the story, tasks, and architecture documents
 func (g *AIDevNotesGenerator) GenerateDevNotes(ctx context.Context, storyDoc *story.StoryDocument) (story.DevNotes, error) {
-	return NewAIGenerator[DevNotesPromptData, story.DevNotes](ctx, g.aiClient, g.config, storyDoc.Story.ID, "devnotes").
+	return ai.NewAIGenerator[DevNotesPromptData, story.DevNotes](ctx, g.aiClient, g.config, storyDoc.Story.ID, "devnotes").
 		WithData(func() (DevNotesPromptData, error) {
 			return DevNotesPromptData{
 				Story: &storyDoc.Story,
@@ -60,7 +61,7 @@ func (g *AIDevNotesGenerator) GenerateDevNotes(ctx context.Context, storyDoc *st
 
 			return systemPrompt, userPrompt, nil
 		}).
-		WithResponseParser(CreateYAMLFileParser[story.DevNotes](g.config, storyDoc.Story.ID, "devnotes", "dev_notes")).
+		WithResponseParser(ai.CreateYAMLFileParser[story.DevNotes](g.config, storyDoc.Story.ID, "devnotes", "dev_notes")).
 		WithValidator(g.validateDevNotes).
 		Generate()
 }

--- a/scripts/bmad-cli/internal/domain/services/story_factory.go
+++ b/scripts/bmad-cli/internal/domain/services/story_factory.go
@@ -85,9 +85,9 @@ func (f *StoryFactory) CreateStory(ctx context.Context, storyNumber string) (*st
 	// Create generators
 	taskGenerator := NewTaskGenerator(f.aiClient, f.config)
 	devNotesGenerator := NewDevNotesGenerator(f.aiClient, f.config)
-	testingGenerator := NewTestingGenerator(f.aiClient, f.config)
-	scenariosGenerator := NewScenariosGenerator(f.aiClient, f.config)
-	qaResultsGenerator := NewQAAssessmentGenerator(f.aiClient, f.config)
+	testingGenerator := NewAITestingGenerator(f.aiClient, f.config)
+	scenariosGenerator := NewAIScenariosGenerator(f.aiClient, f.config)
+	qaResultsGenerator := NewAIQAAssessmentGenerator(f.aiClient, f.config)
 
 	// Generate tasks using AI - fail on any error
 	tasks, err := taskGenerator.GenerateTasks(ctx, storyDoc)

--- a/scripts/bmad-cli/internal/domain/services/task_generator.go
+++ b/scripts/bmad-cli/internal/domain/services/task_generator.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"bmad-cli/internal/common/ai"
 	"context"
 	"fmt"
 
@@ -32,7 +33,7 @@ func NewTaskGenerator(aiClient AIClient, config *config.ViperConfig) *AITaskGene
 
 // GenerateTasks generates story tasks using AI based on the story and architecture documents
 func (g *AITaskGenerator) GenerateTasks(ctx context.Context, storyDoc *story.StoryDocument) ([]story.Task, error) {
-	return NewAIGenerator[TaskPromptData, []story.Task](ctx, g.aiClient, g.config, storyDoc.Story.ID, "tasks").
+	return ai.NewAIGenerator[TaskPromptData, []story.Task](ctx, g.aiClient, g.config, storyDoc.Story.ID, "tasks").
 		WithData(func() (TaskPromptData, error) {
 			return TaskPromptData{
 				Story: &storyDoc.Story,
@@ -58,7 +59,7 @@ func (g *AITaskGenerator) GenerateTasks(ctx context.Context, storyDoc *story.Sto
 
 			return systemPrompt, userPrompt, nil
 		}).
-		WithResponseParser(CreateYAMLFileParser[[]story.Task](g.config, storyDoc.Story.ID, "tasks", "tasks")).
+		WithResponseParser(ai.CreateYAMLFileParser[[]story.Task](g.config, storyDoc.Story.ID, "tasks", "tasks")).
 		WithValidator(func(tasks []story.Task) error {
 			if len(tasks) == 0 {
 				return fmt.Errorf("AI generated no tasks")

--- a/scripts/bmad-cli/internal/infrastructure/epic/epic_loader.go
+++ b/scripts/bmad-cli/internal/infrastructure/epic/epic_loader.go
@@ -7,7 +7,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
-	"bmad-cli/internal/domain/models/epic"
+	"bmad-cli/internal/domain/models"
 	"bmad-cli/internal/domain/models/story"
 	"bmad-cli/internal/infrastructure/config"
 )
@@ -55,7 +55,7 @@ func (el *EpicLoader) parseStoryNumber(storyNumber string) (int, int, error) {
 	return epicNum, storyNum, nil
 }
 
-func (el *EpicLoader) loadEpicFile(epicNum int) (*epic.EpicDocument, error) {
+func (el *EpicLoader) loadEpicFile(epicNum int) (*models.EpicDocument, error) {
 	filename := fmt.Sprintf("epic-%02d-*.yaml", epicNum)
 	pattern := filepath.Join(el.basePath, filename)
 
@@ -78,7 +78,7 @@ func (el *EpicLoader) loadEpicFile(epicNum int) (*epic.EpicDocument, error) {
 		return nil, fmt.Errorf("failed to read epic file %s: %w", epicFilePath, err)
 	}
 
-	var epicDoc epic.EpicDocument
+	var epicDoc models.EpicDocument
 	if err := yaml.Unmarshal(data, &epicDoc); err != nil {
 		return nil, fmt.Errorf("failed to parse epic YAML from %s: %w", epicFilePath, err)
 	}

--- a/scripts/bmad-cli/internal/infrastructure/git/handlers/already_on_story_branch_handler.go
+++ b/scripts/bmad-cli/internal/infrastructure/git/handlers/already_on_story_branch_handler.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"bmad-cli/internal/infrastructure/git"
 	"context"
 	"log/slog"
 )

--- a/scripts/bmad-cli/internal/infrastructure/git/handlers/base_branch_handler.go
+++ b/scripts/bmad-cli/internal/infrastructure/git/handlers/base_branch_handler.go
@@ -1,5 +1,4 @@
 package handlers
-import "bmad-cli/internal/infrastructure/git"
 
 import "context"
 

--- a/scripts/bmad-cli/internal/infrastructure/git/handlers/branch_handler.go
+++ b/scripts/bmad-cli/internal/infrastructure/git/handlers/branch_handler.go
@@ -1,5 +1,4 @@
 package handlers
-import "bmad-cli/internal/infrastructure/git"
 
 import "context"
 

--- a/scripts/bmad-cli/internal/infrastructure/git/handlers/create_branch_handler.go
+++ b/scripts/bmad-cli/internal/infrastructure/git/handlers/create_branch_handler.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"bmad-cli/internal/infrastructure/git"
 	"context"
 	"log/slog"
 )
@@ -9,11 +8,11 @@ import (
 // CreateBranchHandler creates a new branch as the final handler in the chain
 type CreateBranchHandler struct {
 	BaseBranchHandler
-	gitService *git.GitService
+	gitService GitService
 }
 
 // NewCreateBranchHandler creates a new handler
-func NewCreateBranchHandler(gitService *git.GitService) *CreateBranchHandler {
+func NewCreateBranchHandler(gitService GitService) *CreateBranchHandler {
 	return &CreateBranchHandler{
 		gitService: gitService,
 	}

--- a/scripts/bmad-cli/internal/infrastructure/git/handlers/detached_head_handler.go
+++ b/scripts/bmad-cli/internal/infrastructure/git/handlers/detached_head_handler.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"bmad-cli/internal/infrastructure/git"
 	"context"
 	"fmt"
 	"log/slog"
@@ -10,11 +9,11 @@ import (
 // DetachedHeadHandler prevents operations on detached HEAD state
 type DetachedHeadHandler struct {
 	BaseBranchHandler
-	gitService *git.GitService
+	gitService GitService
 }
 
 // NewDetachedHeadHandler creates a new detached HEAD handler
-func NewDetachedHeadHandler(gitService *git.GitService) *DetachedHeadHandler {
+func NewDetachedHeadHandler(gitService GitService) *DetachedHeadHandler {
 	return &DetachedHeadHandler{
 		gitService: gitService,
 	}

--- a/scripts/bmad-cli/internal/infrastructure/git/handlers/dirty_working_tree_handler.go
+++ b/scripts/bmad-cli/internal/infrastructure/git/handlers/dirty_working_tree_handler.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"bmad-cli/internal/infrastructure/git"
 	"context"
 	"fmt"
 	"log/slog"
@@ -10,11 +9,11 @@ import (
 // DirtyWorkingTreeHandler checks for uncommitted changes
 type DirtyWorkingTreeHandler struct {
 	BaseBranchHandler
-	gitService *git.GitService
+	gitService GitService
 }
 
 // NewDirtyWorkingTreeHandler creates a new dirty working tree handler
-func NewDirtyWorkingTreeHandler(gitService *git.GitService) *DirtyWorkingTreeHandler {
+func NewDirtyWorkingTreeHandler(gitService GitService) *DirtyWorkingTreeHandler {
 	return &DirtyWorkingTreeHandler{
 		gitService: gitService,
 	}

--- a/scripts/bmad-cli/internal/infrastructure/git/handlers/force_recreate_handler.go
+++ b/scripts/bmad-cli/internal/infrastructure/git/handlers/force_recreate_handler.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"bmad-cli/internal/infrastructure/git"
 	"context"
 	"log/slog"
 )
@@ -9,11 +8,11 @@ import (
 // ForceRecreateHandler handles the --force flag to recreate branches
 type ForceRecreateHandler struct {
 	BaseBranchHandler
-	gitService *git.GitService
+	gitService GitService
 }
 
 // NewForceRecreateHandler creates a new force recreate handler
-func NewForceRecreateHandler(gitService *git.GitService) *ForceRecreateHandler {
+func NewForceRecreateHandler(gitService GitService) *ForceRecreateHandler {
 	return &ForceRecreateHandler{
 		gitService: gitService,
 	}

--- a/scripts/bmad-cli/internal/infrastructure/git/handlers/git_repo_check_handler.go
+++ b/scripts/bmad-cli/internal/infrastructure/git/handlers/git_repo_check_handler.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"bmad-cli/internal/infrastructure/git"
 	"context"
 	"fmt"
 	"log/slog"
@@ -10,11 +9,11 @@ import (
 // GitRepoCheckHandler validates that the current directory is a git repository
 type GitRepoCheckHandler struct {
 	BaseBranchHandler
-	gitService *git.GitService
+	gitService GitService
 }
 
 // NewGitRepoCheckHandler creates a new git repository check handler
-func NewGitRepoCheckHandler(gitService *git.GitService) *GitRepoCheckHandler {
+func NewGitRepoCheckHandler(gitService GitService) *GitRepoCheckHandler {
 	return &GitRepoCheckHandler{
 		gitService: gitService,
 	}

--- a/scripts/bmad-cli/internal/infrastructure/git/handlers/git_service_interface.go
+++ b/scripts/bmad-cli/internal/infrastructure/git/handlers/git_service_interface.go
@@ -1,0 +1,20 @@
+package handlers
+
+import "context"
+
+// GitService defines the interface for git operations needed by handlers
+// This interface breaks the import cycle between git and git/handlers packages
+type GitService interface {
+	IsGitRepository(ctx context.Context) (bool, error)
+	IsDetachedHead(ctx context.Context) (bool, error)
+	GetCurrentBranch(ctx context.Context) (string, error)
+	IsWorkingTreeClean(ctx context.Context) (bool, error)
+	IsMainBehindOrigin(ctx context.Context) (bool, error)
+	LocalBranchExists(ctx context.Context, branchName string) (bool, error)
+	RemoteBranchExists(ctx context.Context, branchName string) (bool, error)
+	CheckoutRemoteBranch(ctx context.Context, branchName string) error
+	SwitchBranch(ctx context.Context, branchName string) error
+	CreateBranch(ctx context.Context, branchName string) error
+	ForceRecreateBranch(ctx context.Context, branchName string) error
+	PushBranch(ctx context.Context, branchName string) error
+}

--- a/scripts/bmad-cli/internal/infrastructure/git/handlers/local_branch_exists_handler.go
+++ b/scripts/bmad-cli/internal/infrastructure/git/handlers/local_branch_exists_handler.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"bmad-cli/internal/infrastructure/git"
 	"context"
 	"log/slog"
 )
@@ -9,11 +8,11 @@ import (
 // LocalBranchExistsHandler checks if the branch exists locally and switches to it
 type LocalBranchExistsHandler struct {
 	BaseBranchHandler
-	gitService *git.GitService
+	gitService GitService
 }
 
 // NewLocalBranchExistsHandler creates a new handler
-func NewLocalBranchExistsHandler(gitService *git.GitService) *LocalBranchExistsHandler {
+func NewLocalBranchExistsHandler(gitService GitService) *LocalBranchExistsHandler {
 	return &LocalBranchExistsHandler{
 		gitService: gitService,
 	}

--- a/scripts/bmad-cli/internal/infrastructure/git/handlers/main_behind_origin_handler.go
+++ b/scripts/bmad-cli/internal/infrastructure/git/handlers/main_behind_origin_handler.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"bmad-cli/internal/infrastructure/git"
 	"context"
 	"fmt"
 	"log/slog"
@@ -10,11 +9,11 @@ import (
 // MainBehindOriginHandler checks if main is behind origin/main
 type MainBehindOriginHandler struct {
 	BaseBranchHandler
-	gitService *git.GitService
+	gitService GitService
 }
 
 // NewMainBehindOriginHandler creates a new handler
-func NewMainBehindOriginHandler(gitService *git.GitService) *MainBehindOriginHandler {
+func NewMainBehindOriginHandler(gitService GitService) *MainBehindOriginHandler {
 	return &MainBehindOriginHandler{
 		gitService: gitService,
 	}

--- a/scripts/bmad-cli/internal/infrastructure/git/handlers/remote_branch_exists_handler.go
+++ b/scripts/bmad-cli/internal/infrastructure/git/handlers/remote_branch_exists_handler.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"bmad-cli/internal/infrastructure/git"
 	"context"
 	"log/slog"
 )
@@ -9,11 +8,11 @@ import (
 // RemoteBranchExistsHandler checks if the branch exists on remote and checks it out
 type RemoteBranchExistsHandler struct {
 	BaseBranchHandler
-	gitService *git.GitService
+	gitService GitService
 }
 
 // NewRemoteBranchExistsHandler creates a new handler
-func NewRemoteBranchExistsHandler(gitService *git.GitService) *RemoteBranchExistsHandler {
+func NewRemoteBranchExistsHandler(gitService GitService) *RemoteBranchExistsHandler {
 	return &RemoteBranchExistsHandler{
 		gitService: gitService,
 	}

--- a/scripts/bmad-cli/internal/infrastructure/git/handlers/unrelated_branch_handler.go
+++ b/scripts/bmad-cli/internal/infrastructure/git/handlers/unrelated_branch_handler.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"bmad-cli/internal/infrastructure/git"
 	"context"
 	"fmt"
 	"log/slog"


### PR DESCRIPTION
## Summary
Fixes critical architecture inconsistencies identified in BMAD CLI folder/file analysis:

### 🔴 Critical Issues Fixed
1. **Moved AIGenerator from domain/services to common/ai**  
   - AIGenerator is a generic utility builder (not a domain service)
   - Violates DDD principles when placed in domain/services
   - Now correctly located in `internal/common/ai/`

2. **Renamed GitHubService port to GitHubPort**  
   - Port interface was incorrectly named "Service"
   - Violates Hexagonal Architecture (ports ≠ services)
   - Now follows standard port naming convention

3. **Fixed pre-existing import cycle in git handlers**
   - Created `GitService` interface in handlers package  
   - Removed circular dependency: git → handlers → git
   - Build now succeeds without import cycle errors

### 🟡 Medium Issues Fixed  
4. **Standardized AI prefix on all generators**
   - Renamed: `TestingGenerator` → `AITestingGenerator`
   - Renamed: `QAAssessmentGenerator` → `AIQAAssessmentGenerator`  
   - Renamed: `ScenariosGenerator` → `AIScenariosGenerator`
   - Now consistent with `AITaskGenerator` and `AIDevNotesGenerator`

## File Changes
- 25 files changed: 106 insertions(+), 77 deletions(-)
- Moved: `domain/services/ai_generator.go` → `common/ai/generator.go`
- Renamed: `domain/ports/github_service.go` → `domain/ports/github_port.go`
- New: `domain/services/ai_client.go` (interface definition)
- New: `git/handlers/git_service_interface.go` (breaks import cycle)

## Testing
- ✅ Build passes successfully
- ✅ No breaking changes to external APIs
- ✅ All pre-commit hooks pass

## Impact
- Clearer separation of concerns
- Better adherence to Hexagonal Architecture
- Improved code organization
- Consistent naming conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)