### PR TITLE
refactor: standardize port interface naming

### DIFF
--- a/scripts/bmad-cli/internal/application/factories/story_factory.go
+++ b/scripts/bmad-cli/internal/application/factories/story_factory.go
@@ -37,12 +37,12 @@ type TestingRequirementsGenerator interface {
 
 type StoryFactory struct {
 	epicLoader         *epic.EpicLoader
-	aiClient           ports.AIClient
+	aiClient           ports.AIPort
 	config             *config.ViperConfig
 	architectureLoader *docs.ArchitectureLoader
 }
 
-func NewStoryFactory(epicLoader *epic.EpicLoader, aiClient ports.AIClient, config *config.ViperConfig, architectureLoader *docs.ArchitectureLoader) *StoryFactory {
+func NewStoryFactory(epicLoader *epic.EpicLoader, aiClient ports.AIPort, config *config.ViperConfig, architectureLoader *docs.ArchitectureLoader) *StoryFactory {
 	return &StoryFactory{
 		epicLoader:         epicLoader,
 		aiClient:           aiClient,

--- a/scripts/bmad-cli/internal/application/generators/dev_notes_generator.go
+++ b/scripts/bmad-cli/internal/application/generators/dev_notes_generator.go
@@ -21,12 +21,12 @@ type DevNotesPromptData struct {
 
 // AIDevNotesGenerator generates story dev_notes using AI based on templates
 type AIDevNotesGenerator struct {
-	aiClient ports.AIClient
+	aiClient ports.AIPort
 	config   *config.ViperConfig
 }
 
 // NewDevNotesGenerator creates a new AIDevNotesGenerator instance
-func NewDevNotesGenerator(aiClient ports.AIClient, config *config.ViperConfig) *AIDevNotesGenerator {
+func NewDevNotesGenerator(aiClient ports.AIPort, config *config.ViperConfig) *AIDevNotesGenerator {
 	return &AIDevNotesGenerator{
 		aiClient: aiClient,
 		config:   config,

--- a/scripts/bmad-cli/internal/application/generators/qa_assessment_generator.go
+++ b/scripts/bmad-cli/internal/application/generators/qa_assessment_generator.go
@@ -17,7 +17,7 @@ import (
 
 // AIQAAssessmentGenerator generates QA results for stories using AI
 type AIQAAssessmentGenerator struct {
-	aiClient ports.AIClient
+	aiClient ports.AIPort
 	config   *config.ViperConfig
 }
 
@@ -30,7 +30,7 @@ type QAAssessmentData struct {
 }
 
 // NewAIQAAssessmentGenerator creates a new QA assessment generator
-func NewAIQAAssessmentGenerator(aiClient ports.AIClient, config *config.ViperConfig) *AIQAAssessmentGenerator {
+func NewAIQAAssessmentGenerator(aiClient ports.AIPort, config *config.ViperConfig) *AIQAAssessmentGenerator {
 	return &AIQAAssessmentGenerator{
 		aiClient: aiClient,
 		config:   config,

--- a/scripts/bmad-cli/internal/application/generators/scenarios_generator.go
+++ b/scripts/bmad-cli/internal/application/generators/scenarios_generator.go
@@ -15,7 +15,7 @@ import (
 
 // AIScenariosGenerator generates test scenarios for stories using AI
 type AIScenariosGenerator struct {
-	aiClient ports.AIClient
+	aiClient ports.AIPort
 	config   *config.ViperConfig
 }
 
@@ -29,7 +29,7 @@ type ScenariosData struct {
 }
 
 // NewAIScenariosGenerator creates a new test scenarios generator
-func NewAIScenariosGenerator(aiClient ports.AIClient, config *config.ViperConfig) *AIScenariosGenerator {
+func NewAIScenariosGenerator(aiClient ports.AIPort, config *config.ViperConfig) *AIScenariosGenerator {
 	return &AIScenariosGenerator{
 		aiClient: aiClient,
 		config:   config,

--- a/scripts/bmad-cli/internal/application/generators/task_generator.go
+++ b/scripts/bmad-cli/internal/application/generators/task_generator.go
@@ -20,12 +20,12 @@ type TaskPromptData struct {
 
 // AITaskGenerator generates story tasks using AI based on templates
 type AITaskGenerator struct {
-	aiClient ports.AIClient
+	aiClient ports.AIPort
 	config   *config.ViperConfig
 }
 
 // NewTaskGenerator creates a new AITaskGenerator instance
-func NewTaskGenerator(aiClient ports.AIClient, config *config.ViperConfig) *AITaskGenerator {
+func NewTaskGenerator(aiClient ports.AIPort, config *config.ViperConfig) *AITaskGenerator {
 	return &AITaskGenerator{
 		aiClient: aiClient,
 		config:   config,

--- a/scripts/bmad-cli/internal/application/generators/testing_generator.go
+++ b/scripts/bmad-cli/internal/application/generators/testing_generator.go
@@ -15,7 +15,7 @@ import (
 
 // AITestingGenerator generates testing requirements for stories using AI
 type AITestingGenerator struct {
-	aiClient ports.AIClient
+	aiClient ports.AIPort
 	config   *config.ViperConfig
 }
 
@@ -28,7 +28,7 @@ type TestingData struct {
 }
 
 // NewAITestingGenerator creates a new testing requirements generator
-func NewAITestingGenerator(aiClient ports.AIClient, config *config.ViperConfig) *AITestingGenerator {
+func NewAITestingGenerator(aiClient ports.AIPort, config *config.ViperConfig) *AITestingGenerator {
 	return &AITestingGenerator{
 		aiClient: aiClient,
 		config:   config,

--- a/scripts/bmad-cli/internal/domain/ports/ai_port.go
+++ b/scripts/bmad-cli/internal/domain/ports/ai_port.go
@@ -6,8 +6,8 @@ import (
 	"bmad-cli/internal/adapters/ai"
 )
 
-// AIClient defines the interface for AI communication
-// This interface belongs in domain/services as it represents a domain service contract
-type AIClient interface {
+// AIPort defines the interface for AI communication
+// This port interface represents the contract for AI operations in the domain layer
+type AIPort interface {
 	ExecutePromptWithSystem(ctx context.Context, systemPrompt string, userPrompt string, model string, mode ai.ExecutionMode) (string, error)
 }

--- a/scripts/bmad-cli/internal/domain/ports/git_port.go
+++ b/scripts/bmad-cli/internal/domain/ports/git_port.go
@@ -1,10 +1,10 @@
-package handlers
+package ports
 
 import "context"
 
-// GitService defines the interface for git operations needed by handlers
-// This interface breaks the import cycle between git and git/handlers packages
-type GitService interface {
+// GitPort defines the interface for git operations
+// This port interface represents the contract for git operations in the domain layer
+type GitPort interface {
 	IsGitRepository(ctx context.Context) (bool, error)
 	IsDetachedHead(ctx context.Context) (bool, error)
 	GetCurrentBranch(ctx context.Context) (string, error)

--- a/scripts/bmad-cli/internal/infrastructure/git/handlers/create_branch_handler.go
+++ b/scripts/bmad-cli/internal/infrastructure/git/handlers/create_branch_handler.go
@@ -3,16 +3,18 @@ package handlers
 import (
 	"context"
 	"log/slog"
+
+	"bmad-cli/internal/domain/ports"
 )
 
 // CreateBranchHandler creates a new branch as the final handler in the chain
 type CreateBranchHandler struct {
 	BaseBranchHandler
-	gitService GitService
+	gitService ports.GitPort
 }
 
 // NewCreateBranchHandler creates a new handler
-func NewCreateBranchHandler(gitService GitService) *CreateBranchHandler {
+func NewCreateBranchHandler(gitService ports.GitPort) *CreateBranchHandler {
 	return &CreateBranchHandler{
 		gitService: gitService,
 	}

--- a/scripts/bmad-cli/internal/infrastructure/git/handlers/detached_head_handler.go
+++ b/scripts/bmad-cli/internal/infrastructure/git/handlers/detached_head_handler.go
@@ -4,16 +4,17 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"bmad-cli/internal/domain/ports"
 )
 
 // DetachedHeadHandler prevents operations on detached HEAD state
 type DetachedHeadHandler struct {
 	BaseBranchHandler
-	gitService GitService
+	gitService ports.GitPort
 }
 
 // NewDetachedHeadHandler creates a new detached HEAD handler
-func NewDetachedHeadHandler(gitService GitService) *DetachedHeadHandler {
+func NewDetachedHeadHandler(gitService ports.GitPort) *DetachedHeadHandler {
 	return &DetachedHeadHandler{
 		gitService: gitService,
 	}

--- a/scripts/bmad-cli/internal/infrastructure/git/handlers/dirty_working_tree_handler.go
+++ b/scripts/bmad-cli/internal/infrastructure/git/handlers/dirty_working_tree_handler.go
@@ -4,16 +4,17 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"bmad-cli/internal/domain/ports"
 )
 
 // DirtyWorkingTreeHandler checks for uncommitted changes
 type DirtyWorkingTreeHandler struct {
 	BaseBranchHandler
-	gitService GitService
+	gitService ports.GitPort
 }
 
 // NewDirtyWorkingTreeHandler creates a new dirty working tree handler
-func NewDirtyWorkingTreeHandler(gitService GitService) *DirtyWorkingTreeHandler {
+func NewDirtyWorkingTreeHandler(gitService ports.GitPort) *DirtyWorkingTreeHandler {
 	return &DirtyWorkingTreeHandler{
 		gitService: gitService,
 	}

--- a/scripts/bmad-cli/internal/infrastructure/git/handlers/force_recreate_handler.go
+++ b/scripts/bmad-cli/internal/infrastructure/git/handlers/force_recreate_handler.go
@@ -3,16 +3,17 @@ package handlers
 import (
 	"context"
 	"log/slog"
+	"bmad-cli/internal/domain/ports"
 )
 
 // ForceRecreateHandler handles the --force flag to recreate branches
 type ForceRecreateHandler struct {
 	BaseBranchHandler
-	gitService GitService
+	gitService ports.GitPort
 }
 
 // NewForceRecreateHandler creates a new force recreate handler
-func NewForceRecreateHandler(gitService GitService) *ForceRecreateHandler {
+func NewForceRecreateHandler(gitService ports.GitPort) *ForceRecreateHandler {
 	return &ForceRecreateHandler{
 		gitService: gitService,
 	}

--- a/scripts/bmad-cli/internal/infrastructure/git/handlers/git_repo_check_handler.go
+++ b/scripts/bmad-cli/internal/infrastructure/git/handlers/git_repo_check_handler.go
@@ -4,16 +4,17 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"bmad-cli/internal/domain/ports"
 )
 
 // GitRepoCheckHandler validates that the current directory is a git repository
 type GitRepoCheckHandler struct {
 	BaseBranchHandler
-	gitService GitService
+	gitService ports.GitPort
 }
 
 // NewGitRepoCheckHandler creates a new git repository check handler
-func NewGitRepoCheckHandler(gitService GitService) *GitRepoCheckHandler {
+func NewGitRepoCheckHandler(gitService ports.GitPort) *GitRepoCheckHandler {
 	return &GitRepoCheckHandler{
 		gitService: gitService,
 	}

--- a/scripts/bmad-cli/internal/infrastructure/git/handlers/local_branch_exists_handler.go
+++ b/scripts/bmad-cli/internal/infrastructure/git/handlers/local_branch_exists_handler.go
@@ -3,16 +3,17 @@ package handlers
 import (
 	"context"
 	"log/slog"
+	"bmad-cli/internal/domain/ports"
 )
 
 // LocalBranchExistsHandler checks if the branch exists locally and switches to it
 type LocalBranchExistsHandler struct {
 	BaseBranchHandler
-	gitService GitService
+	gitService ports.GitPort
 }
 
 // NewLocalBranchExistsHandler creates a new handler
-func NewLocalBranchExistsHandler(gitService GitService) *LocalBranchExistsHandler {
+func NewLocalBranchExistsHandler(gitService ports.GitPort) *LocalBranchExistsHandler {
 	return &LocalBranchExistsHandler{
 		gitService: gitService,
 	}

--- a/scripts/bmad-cli/internal/infrastructure/git/handlers/main_behind_origin_handler.go
+++ b/scripts/bmad-cli/internal/infrastructure/git/handlers/main_behind_origin_handler.go
@@ -4,16 +4,17 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"bmad-cli/internal/domain/ports"
 )
 
 // MainBehindOriginHandler checks if main is behind origin/main
 type MainBehindOriginHandler struct {
 	BaseBranchHandler
-	gitService GitService
+	gitService ports.GitPort
 }
 
 // NewMainBehindOriginHandler creates a new handler
-func NewMainBehindOriginHandler(gitService GitService) *MainBehindOriginHandler {
+func NewMainBehindOriginHandler(gitService ports.GitPort) *MainBehindOriginHandler {
 	return &MainBehindOriginHandler{
 		gitService: gitService,
 	}

--- a/scripts/bmad-cli/internal/infrastructure/git/handlers/remote_branch_exists_handler.go
+++ b/scripts/bmad-cli/internal/infrastructure/git/handlers/remote_branch_exists_handler.go
@@ -3,16 +3,17 @@ package handlers
 import (
 	"context"
 	"log/slog"
+	"bmad-cli/internal/domain/ports"
 )
 
 // RemoteBranchExistsHandler checks if the branch exists on remote and checks it out
 type RemoteBranchExistsHandler struct {
 	BaseBranchHandler
-	gitService GitService
+	gitService ports.GitPort
 }
 
 // NewRemoteBranchExistsHandler creates a new handler
-func NewRemoteBranchExistsHandler(gitService GitService) *RemoteBranchExistsHandler {
+func NewRemoteBranchExistsHandler(gitService ports.GitPort) *RemoteBranchExistsHandler {
 	return &RemoteBranchExistsHandler{
 		gitService: gitService,
 	}

--- a/scripts/bmad-cli/internal/pkg/ai/generator.go
+++ b/scripts/bmad-cli/internal/pkg/ai/generator.go
@@ -7,21 +7,16 @@ import (
 	"os"
 
 	"bmad-cli/internal/adapters/ai"
+	"bmad-cli/internal/domain/ports"
 	"bmad-cli/internal/infrastructure/config"
 
 	"gopkg.in/yaml.v3"
 )
 
-// AIClient defines the interface for AI communication
-// Note: This duplicates the interface from domain/services for package independence
-type AIClient interface {
-	ExecutePromptWithSystem(ctx context.Context, systemPrompt string, userPrompt string, model string, mode ai.ExecutionMode) (string, error)
-}
-
 // AIGenerator is a generic AI content generator with builder pattern
 type AIGenerator[T1 any, T2 any] struct {
 	ctx            context.Context
-	aiClient       AIClient
+	aiClient       ports.AIPort
 	config         *config.ViperConfig
 	storyID        string
 	filePrefix     string
@@ -34,7 +29,7 @@ type AIGenerator[T1 any, T2 any] struct {
 }
 
 // NewAIGenerator creates a new generator instance
-func NewAIGenerator[T1 any, T2 any](ctx context.Context, aiClient AIClient, config *config.ViperConfig, storyID string, filePrefix string) *AIGenerator[T1, T2] {
+func NewAIGenerator[T1 any, T2 any](ctx context.Context, aiClient ports.AIPort, config *config.ViperConfig, storyID string, filePrefix string) *AIGenerator[T1, T2] {
 	modeFactory := ai.NewModeFactory(config)
 	return &AIGenerator[T1, T2]{
 		ctx:        ctx,


### PR DESCRIPTION
## Summary

Standardize all port interface naming to follow consistent `*Port` convention and ensure proper architectural placement.

## Changes

### Phase 1: AIClient → AIPort
**Renamed interface and file:**
- `AIClient` → `AIPort` in `domain/ports/ai_port.go`
- File: `ai_client_port.go` → `ai_port.go`

**Removed duplication:**
- Deleted duplicate `AIClient` interface from `pkg/ai/generator.go`
- Now uses single source of truth: `ports.AIPort`

**Updated references (18 locations):**
- All 5 generators (task, dev_notes, testing, scenarios, qa_assessment)
- `application/factories/story_factory.go`
- `pkg/ai/generator.go`

### Phase 2: GitService → GitPort (Moved to Domain)
**Moved and renamed:**
- `infrastructure/git/handlers/git_service_interface.go` → `domain/ports/git_port.go`
- Interface: `GitService` → `GitPort`
- Package: `handlers` → `ports`

**Updated references (8 handler files):**
- All git handlers now import and use `ports.GitPort`
- `BranchManager` unchanged (passes `*GitService` which implements `ports.GitPort`)

## Result: Consistent Port Structure

```
domain/ports/
├── github_port.go → GitHubPort interface
├── ai_port.go     → AIPort interface
└── git_port.go    → GitPort interface
```

**Benefits:**
✅ All port interfaces follow `*Port` naming convention  
✅ All ports in correct architectural layer (`domain/ports/`)  
✅ No interface duplication  
✅ Clear separation between ports (interfaces) and adapters (implementations)  
✅ Follows Hexagonal Architecture / Ports & Adapters pattern  

## Verification

- ✅ Build passes
- ✅ All imports resolved
- ✅ Pre-commit hooks pass
- ✅ No linting errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>