### PR TITLE
feat(bmad-cli): reshape count checklist prompts into violation maps

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,2 +1,14 @@
 {
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "printf '%s' '{\"hookSpecificOutput\":{\"hookEventName\":\"UserPromptSubmit\",\"additionalContext\":\"Reminder: never offer commits, commit breakdowns, or ready-to-commit narration unless the user has explicitly asked to commit. Wait for an explicit commit/push/merge instruction before invoking pr-commit/pr-merge skills.\"}}'"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/.claude/skills/pr-commit/SKILL.md
+++ b/.claude/skills/pr-commit/SKILL.md
@@ -105,23 +105,25 @@ Invoke the `pr-update` skill to update the PR title and description to reflect a
 
 ### 10. Report Execution
 
-Before ending the turn, emit a table listing every step 0–9 with its outcome: `run` or `failed-then-fixed`. The table must have ten rows. If any row would read `skipped`, the skill has been violated — run the missing step(s) and re-report. Do not close the turn without this table.
+Before ending the turn, emit a single one-line status for every step 0–9 in order, separated by ` · `. Each entry has the form `N. <label> ✅` when the step ran (including `failed-then-fixed`) or `N. <label> ❌` when it did not. The line must contain all ten entries. If any entry is ❌, the skill has been violated — run the missing step(s) and re-report.
+
+Use these exact labels:
+
+- `0. Branch checked`
+- `1. Lint passed`
+- `2. Unit tests passed`
+- `3. E2E tests passed`
+- `4. Pre-commit passed`
+- `5. Memory updated`
+- `6. Changes reviewed`
+- `7. Commit created`
+- `8. Pushed`
+- `9. PR updated`
 
 Example:
 
 ```
-| Step | Outcome |
-|---|---|
-| 0. Branch | run |
-| 1. Lint | run |
-| 2. Unit tests | run |
-| 3. E2E tests | run |
-| 4. Pre-commit hooks | run |
-| 5. Update memory | run |
-| 6. Review changes | run |
-| 7. Stage & commit | run |
-| 8. Push | run |
-| 9. Update PR | run |
+0. Branch checked ✅ · 1. Lint passed ✅ · 2. Unit tests passed ✅ · 3. E2E tests passed ✅ · 4. Pre-commit passed ✅ · 5. Memory updated ✅ · 6. Changes reviewed ✅ · 7. Commit created ✅ · 8. Pushed ✅ · 9. PR updated ✅
 ```
 
 ## Commit Message Format

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,14 +225,44 @@ type DataCache struct { /* caching complexity */ }
 **Current Status (as of 2025-10-10):**
 - Compliance tracked through code review
 
-## Interactive Testing with Terminal MCP
+## Shell Usage
 
-When testing the app, use the terminal MCP to create an interactive bash session.
-Before launching the app, unset `CLAUDECODE` so the app can spawn Claude Code as a subprocess:
+**Do not use `cd` to change the working directory.** Always run commands from
+the repository root using absolute or `-C <path>` flags (e.g. `go build -C
+scripts/bmad-cli`). This keeps paths predictable across turns and prevents the
+working directory from drifting into nested subdirectories.
+
+## Testing `scripts/bmad-cli/`
+
+All bmad-cli testing happens from the repository root. **Use the terminal MCP**
+(`mcp__terminal__create_session` + `send_command`) for an interactive bash
+session so the CLI can spawn Claude Code as a subprocess. Before launching,
+unset `CLAUDECODE`:
 
 ```bash
-env -u CLAUDECODE ./your-app
+env -u CLAUDECODE ./scripts/bmad-cli/bmad-cli <args>
 ```
+
+### Test commands (run from repo root)
+
+1. **Build:**
+   ```bash
+   go build -C scripts/bmad-cli -o ./bmad-cli
+   ```
+2. **Invoke a command:**
+   ```bash
+   env -u CLAUDECODE ./scripts/bmad-cli/bmad-cli us refine <story-id>
+   env -u CLAUDECODE ./scripts/bmad-cli/bmad-cli us create <story-id>
+   env -u CLAUDECODE ./scripts/bmad-cli/bmad-cli us generate_tests
+   env -u CLAUDECODE ./scripts/bmad-cli/bmad-cli us implement
+   ```
+
+### Timing
+
+`us refine` drives many sequential Claude calls and typically takes **about
+5 minutes** end-to-end. When invoking it via the terminal MCP, send the
+command, then `sleep 300` (or poll with `read_output` every ~60s) before
+reading the final tail. Do not abort early.
 
 ## Notes
 

--- a/bdd-cli/checklists/us-refine.yaml
+++ b/bdd-cli/checklists/us-refine.yaml
@@ -248,8 +248,14 @@ sections:
                   - and: "<additional outcome if needed>"
           ```
 
-      - Q: "Count ACs with vague words (properly, correctly, appropriate, user-friendly, fast, etc.) in their description or steps. Answer as integer."
-        A: "0"
+      - Q: |
+          List every AC whose description or steps contain a vague word from the
+          forbidden qualifiers list in the terms reference (properly, correctly,
+          appropriate, user-friendly, fast, etc.).
+          Answer as a YAML map keyed by AC id; each value is a list of the vague
+          words found in that AC.
+          If no violations, answer with an empty map `{}`.
+        A: "{}"
         rationale: "Vague words cannot be tested objectively."
         docs:
           - prd
@@ -262,16 +268,13 @@ sections:
           Use the forbidden qualifiers list from the terms reference document.
           Replace each forbidden qualifier with specific, measurable criteria.
 
-          Output format (YAML list):
-          ```yaml
-          - original: "<AC text with vague word>"
-            vague_word: "<the vague word>"
-            issue: "Cannot be tested objectively"
-            rewritten: "<AC with specific measurable criteria>"
-          ```
-
-      - Q: "Count ACs whose Given/When/Then steps use action verbs from the forbidden actions list in the terms reference document. Answer as integer."
-        A: "0"
+      - Q: |
+          List every AC whose Given/When/Then steps use action verbs from the
+          forbidden actions list in the terms reference document.
+          Answer as a YAML map keyed by AC id; each value is a list of the
+          forbidden verbs used in that AC.
+          If no violations, answer with an empty map `{}`.
+        A: "{}"
         rationale: "Every step must use concrete, reproducible action verbs defined in the terms reference. Forbidden verbs do not specify the interaction mechanism and cannot be automated."
         docs:
           - prd
@@ -281,21 +284,20 @@ sections:
           Rewrite each step that uses a forbidden action verb.
 
           Use the terms reference document to select a concrete replacement verb
-          from the appropriate allowed action category (conversational, ui, observation, or system).
+          from the appropriate allowed action category (conversational, ui,
+          observation, or system).
 
-          The replacement must specify the interaction mechanism — not just the user's intent.
+          The replacement must specify the interaction mechanism — not just the
+          user's intent.
 
-          Output format (YAML list):
-          ```yaml
-          - ac_id: "<AC id>"
-            step_type: "given|when|then"
-            original: "<the step text with forbidden verb>"
-            forbidden_verb: "<the forbidden verb used>"
-            rewritten: "<step using an allowed verb from terms reference>"
-          ```
-
-      - Q: "Count ACs that describe implementation (endpoint created, database updated) vs observable behavior (using allowed action verbs from the terms reference). Answer implementation count as integer."
-        A: "0"
+      - Q: |
+          List every AC that describes implementation (endpoint created,
+          database updated, etc.) instead of observable behavior using allowed
+          action verbs from the terms reference.
+          Answer as a YAML map keyed by AC id; each value is a list of
+          implementation phrases found in that AC.
+          If no violations, answer with an empty map `{}`.
+        A: "{}"
         rationale: "ACs describe observable behavior, not technical implementation."
         docs:
           - prd

--- a/scripts/bmad-cli/internal/app/commands/table_renderer.go
+++ b/scripts/bmad-cli/internal/app/commands/table_renderer.go
@@ -68,7 +68,9 @@ func (r *TableRenderer) renderTable(report *checklist.ChecklistReport) {
 	for _, result := range report.Results {
 		question := truncateString(result.Question, maxQuestionLen)
 		expected := truncateString(result.ExpectedAnswer, answerMaxLen)
-		actual := truncateString(result.ActualAnswer, answerMaxLen)
+		actual := summarizeAnswer(
+			result.ExpectedAnswer, result.ActualAnswer, answerMaxLen,
+		)
 		status := r.formatStatus(result.Status)
 
 		_, _ = fmt.Fprintf(tabWriter, "%s\t%s\t%s\t%s\t%s\n",
@@ -158,6 +160,28 @@ func (r *TableRenderer) renderFixPrompts(report *checklist.ChecklistReport) {
 	}
 
 	_, _ = fmt.Fprintln(r.writer, separatorLine)
+}
+
+// summarizeAnswer renders the ACTUAL column for a row. For map-typed
+// questions (expected == "{}") it collapses a non-empty map to "N AC(s)"
+// and preserves "{}" for empty maps. Other answers fall back to
+// truncateString.
+func summarizeAnswer(expected, actual string, maxLen int) string {
+	if strings.TrimSpace(expected) != "{}" {
+		return truncateString(actual, maxLen)
+	}
+
+	node, ok := checklist.ParseAnswerMap(actual)
+	if !ok {
+		return truncateString(actual, maxLen)
+	}
+
+	count := checklist.AnswerMapEntryCount(node)
+	if count == 0 {
+		return "{}"
+	}
+
+	return fmt.Sprintf("%d AC(s)", count)
 }
 
 // truncateString truncates a string to maxLen, adding "..." if needed.

--- a/scripts/bmad-cli/internal/app/commands/us_validation_command.go
+++ b/scripts/bmad-cli/internal/app/commands/us_validation_command.go
@@ -30,6 +30,7 @@ const (
 	separatorWidth             = 80
 	storyFilePermissions       = 0o644
 	storyDirPermissions        = 0o755
+	failureActualSummaryLen    = 40
 )
 
 // CommandConfig describes a single `us` subcommand: which checklist file it
@@ -652,10 +653,39 @@ func (c *USValidationCommand) displayFailureInfo(
 	console.Separator("=", separatorWidth)
 	console.Printf("Question: %s\n", failedCheck.Question)
 	console.Printf("Expected: %s\n", failedCheck.ExpectedAnswer)
-	console.Printf("Actual: %s\n", failedCheck.ActualAnswer)
+	console.Printf("Actual: %s\n", summarizeAnswer(
+		failedCheck.ExpectedAnswer,
+		failedCheck.ActualAnswer,
+		failureActualSummaryLen,
+	))
 
 	if failedCheck.Rationale != "" {
 		console.Printf("Rationale: %s\n", failedCheck.Rationale)
+	}
+
+	c.displayViolations(failedCheck)
+}
+
+// displayViolations prints the raw violation map for map-typed checks so the
+// user can see which ACs and which terms triggered the failure.
+func (c *USValidationCommand) displayViolations(
+	failedCheck *checklistmodels.ValidationResult,
+) {
+	if strings.TrimSpace(failedCheck.ExpectedAnswer) != "{}" {
+		return
+	}
+
+	node, ok := checklistmodels.ParseAnswerMap(failedCheck.ActualAnswer)
+	if !ok || checklistmodels.AnswerMapEntryCount(node) == 0 {
+		return
+	}
+
+	console.Println("Violations:")
+
+	for _, line := range strings.Split(
+		strings.TrimRight(failedCheck.ActualAnswer, "\n"), "\n",
+	) {
+		console.Printf("  %s\n", line)
 	}
 }
 

--- a/scripts/bmad-cli/internal/app/generators/validate/checklist_evaluator.go
+++ b/scripts/bmad-cli/internal/app/generators/validate/checklist_evaluator.go
@@ -254,10 +254,12 @@ func (e *ChecklistEvaluator) evaluatePrompt(
 	}, nil
 }
 
-// resultYAML represents the structure of the result file.
+// resultYAML represents the structure of the result file. The Answer field
+// uses yaml.Node so it can hold either a scalar (integer, yes/no, percentage)
+// or a mapping (violation map keyed by AC id).
 type resultYAML struct {
-	Answer    string `yaml:"answer"`
-	FixPrompt string `yaml:"fix_prompt,omitempty"`
+	Answer    yaml.Node `yaml:"answer"`
+	FixPrompt string    `yaml:"fix_prompt,omitempty"`
 }
 
 // ParsedResult contains the parsed answer and optional fix prompt.
@@ -295,9 +297,32 @@ func (e *ChecklistEvaluator) parseResultFile(response, path string) ParsedResult
 	}
 
 	return ParsedResult{
-		Answer:    strings.TrimSpace(result.Answer),
+		Answer:    renderAnswerNode(&result.Answer),
 		FixPrompt: strings.TrimSpace(result.FixPrompt),
 	}
+}
+
+// renderAnswerNode converts the YAML answer node back to its text form. For
+// scalars this returns the raw value (e.g. "5", "yes"); for mappings and
+// sequences it preserves the YAML block structure so downstream display and
+// comparison logic see the same text the user would read in the result file.
+func renderAnswerNode(node *yaml.Node) string {
+	if node == nil || node.Kind == 0 {
+		return ""
+	}
+
+	if node.Kind == yaml.ScalarNode {
+		return strings.TrimSpace(node.Value)
+	}
+
+	out, err := yaml.Marshal(node)
+	if err != nil {
+		slog.Warn("Failed to marshal answer node", "error", err)
+
+		return ""
+	}
+
+	return strings.TrimRight(string(out), "\n")
 }
 
 // compareAnswers compares actual answer to expected and returns status.
@@ -327,6 +352,11 @@ func (e *ChecklistEvaluator) trySpecializedComparison(
 	expected, actual string,
 	acCount int,
 ) (checklist.Status, bool) {
+	// Handle empty-map expectation: "{}" means "no violations"
+	if expected == "{}" {
+		return e.compareEmptyMap(actual), true
+	}
+
 	// Handle special case: "= total AC count" or similar
 	if e.isACCountComparison(expected) {
 		return e.compareToACCount(expected, actual, acCount), true
@@ -357,6 +387,21 @@ func (e *ChecklistEvaluator) trySpecializedComparison(
 // isACCountComparison checks if the expected value is an AC count comparison.
 func (e *ChecklistEvaluator) isACCountComparison(expected string) bool {
 	return strings.Contains(expected, "total") && strings.Contains(expected, "ac")
+}
+
+// compareEmptyMap returns PASS when actual parses as an empty YAML mapping,
+// FAIL otherwise (non-empty map, non-map value, or parse error).
+func (e *ChecklistEvaluator) compareEmptyMap(actual string) checklist.Status {
+	node, ok := checklist.ParseAnswerMap(actual)
+	if !ok {
+		return checklist.StatusFail
+	}
+
+	if checklist.AnswerMapEntryCount(node) == 0 {
+		return checklist.StatusPass
+	}
+
+	return checklist.StatusFail
 }
 
 // isGreaterOrEqualComparison checks for >= or ≥ prefix.

--- a/scripts/bmad-cli/internal/domain/models/checklist/answer_map.go
+++ b/scripts/bmad-cli/internal/domain/models/checklist/answer_map.go
@@ -1,0 +1,50 @@
+package checklist
+
+import (
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// mappingNodeEntryStride is the number of yaml.Node children per map entry
+// (one for the key, one for the value).
+const mappingNodeEntryStride = 2
+
+// ParseAnswerMap parses a raw answer string as a YAML mapping node.
+// Returns the mapping node and true when the answer is a valid YAML map
+// (possibly empty). Returns nil, false for scalars, sequences, or parse errors.
+func ParseAnswerMap(raw string) (*yaml.Node, bool) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return nil, false
+	}
+
+	var root yaml.Node
+
+	err := yaml.Unmarshal([]byte(trimmed), &root)
+	if err != nil {
+		return nil, false
+	}
+
+	// Document nodes wrap the actual content in Content[0].
+	node := &root
+	if node.Kind == yaml.DocumentNode && len(node.Content) > 0 {
+		node = node.Content[0]
+	}
+
+	if node.Kind != yaml.MappingNode {
+		return nil, false
+	}
+
+	return node, true
+}
+
+// AnswerMapEntryCount returns the number of top-level keys in a YAML map node.
+// Returns 0 for nil or non-mapping nodes.
+func AnswerMapEntryCount(node *yaml.Node) int {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return 0
+	}
+
+	return len(node.Content) / mappingNodeEntryStride
+}

--- a/scripts/bmad-cli/templates/us-checklist.system.prompt.tpl
+++ b/scripts/bmad-cli/templates/us-checklist.system.prompt.tpl
@@ -31,3 +31,13 @@ When generating fix_prompt examples:
 - count questions → number (e.g., "3")
 - choice questions → one option (e.g., "goal")
 - percentage questions → number (e.g., "80")
+- map/list questions → YAML map keyed as instructed in the question
+  (use an empty map `{}` when there are no entries).
+  Example of a non-empty answer:
+
+  ```yaml
+  AC3:
+    - properly shares
+  AC4:
+    - correctly updates
+  ```


### PR DESCRIPTION
- Reshape three `us refine` checklist prompts (vague words, forbidden verbs, implementation-vs-observable) from "Count ... Answer as integer / Expected 0" to "List every AC ... Answer as YAML map / Expected {}" so the answer itself names the offending AC and the offending terms
- Add `checklist.ParseAnswerMap` and `AnswerMapEntryCount` helpers shared by the evaluator and the renderer
- Extend `trySpecializedComparison` with a `compareEmptyMap` branch: PASS only when `actual` parses to an empty YAML mapping
- Change `resultYAML.Answer` to `yaml.Node` and re-marshal it back to text so map-valued answers no longer fail with `cannot unmarshal !!map into string`
- Add `summarizeAnswer` in the table renderer: empty map renders as `{}`, non-empty renders as `N AC(s)`; other rows keep the old `truncateString` behaviour
- Add `displayViolations` under the `CHECK FAILED` block so the full per-AC violation map is printed inline when a map check fails
- Update `us-checklist.system.prompt.tpl` with an explicit `map/list questions` bullet and an example empty-map answer
- Restore remediation-only `F:` templates on vague-words and forbidden-verbs checks (drop the duplicate diagnostic YAML format — that's now the answer shape)
- Document bmad-cli test commands, terminal MCP usage, 5-minute `us refine` timing, and the no-`cd` rule in CLAUDE.md
- Persist `UserPromptSubmit` commit-restraint reminder hook in `.claude/settings.json`
- Replace the ten-row markdown table in `pr-commit` step 10 with a one-line emoji status (`0. Branch checked ✅ · 1. Lint passed ✅ · ...`)

Why: when an integer-count check failed (e.g. forbidden verbs = 1) the summary table and `CHECK FAILED` block told the user a violation existed but hid which AC and which term triggered it. The detail had to be dug out of `tmp/.../NN-...-result.yaml`. Reshaping the answer itself into a map of AC id -> offending terms makes the evidence visible in the terminal output, and keeps the fix-prompt path (`F:`) available for remediation on `--fix` runs.
