### PR TITLE
chore(bdd-cli): reshape us-create checklist to universal pass/fail + context output

### DIFF
--- a/bdd-cli/checklists/us-create.yaml
+++ b/bdd-cli/checklists/us-create.yaml
@@ -6,79 +6,123 @@
 # - Mike Cohn User Stories: https://www.mountaingoatsoftware.com/agile/user-stories
 
 version: "1.0"
-last_updated: "2026-04-18"
+last_updated: "2026-04-20"
 
 sections:
   - id: format
     name: "Story Format"
     description: "Overall story statement quality"
     validation_prompts:
-      - Q: "Does the story follow the format 'As a [type of user], I want [some goal] so that [some reason]'? Answer: yes/no"
-        A: "yes"
+      - Q: |
+          Does the story follow the format
+          "As a [type of user], I want [some goal] so that [some reason]"?
+
+          Pass when all three clauses (as_a, i_want, so_that) are present
+          and the statement reads as a coherent user story.
+          Fail when any clause is missing or the format is not recognizable.
+
+          Context: emit a single line per clause.
+            - "as_a: present — '<quoted role>'"
+            - "i_want: present — '<short summary>'"
+            - "so_that: present — '<short summary>'"
+            or
+            - "<clause>: missing"
         rationale: "Standard user story format ensures clarity and consistency."
         docs:
           - prd
           - terms
           - architecture_yaml
 
-      - Q: "Count total words in the user story statement (As a... I want... So that...). Answer as integer."
-        A: "≤50"
+      - Q: |
+          Count total words in the user story statement
+          (As a... I want... So that...).
+
+          Pass when the count is 50 or fewer.
+          Fail when the count exceeds 50.
+
+          Context: emit a single line stating the count.
+            - "Word count: <N>"
         rationale: "Must fit on 3x5 index card. Typically 20-50 words maximum."
         docs:
           - prd
           - terms
           - architecture_yaml
 
-      - Q: "Count internal implementation terms in the story statement (As a... I want... So that...). Internal implementation terms are OUR technical decisions: SDK, REST, GraphQL, database, endpoint, WebSocket, JWT, microservice, cache, API (when referring to our API). NOT implementation terms: (1) Product names users interact with (Google Docs, Gmail, Slack); (2) 3rd-party authentication methods users perform (OAuth, service account, API key) - these describe USER actions with external services, not our implementation. First explain your reasoning, then answer as integer."
-        A: "0"
-        rationale: "Card should describe WHAT user needs, not HOW to implement."
-        docs:
-          - prd
-          - terms
-          - architecture_yaml
 
-      - Q: "Does the story prescribe a specific solution or describe a user need? A solution prescription dictates OUR internal architecture: specific frameworks, database schemas, API designs, caching strategies. NOT solution prescription: (1) Product names users interact with (Google Docs, Gmail, Slack) - these define the product domain; (2) 3rd-party authentication methods users perform (OAuth, service account, API key) - these describe user actions with external services. First explain your reasoning, then answer: need/solution"
-        A: "need"
-        rationale: "Stories are placeholders for conversation, not specifications."
-        docs:
-          - prd
-          - terms
-          - architecture_yaml
 
   - id: who
     name: "User Role"
     description: "The user role - must be an actual human who interacts with the system"
     validation_prompts:
-      - Q: "Is the role a human persona (not system, database, API, service)? Answer: yes/no"
-        A: "yes"
-        rationale: "Only humans perceive value. 'As a database' is meaningless."
-        docs:
-          - prd
-          - terms
-          - architecture_yaml
+      - Q: |
+          Does the "as_a" clause use a role defined in the terms reference?
 
-      - Q: "Is the persona more specific than generic 'user' or 'customer'? Answer: yes/no"
-        A: "yes"
-        rationale: "Specific personas (admin, first-time visitor, power user) guide prioritization."
+          Read the roles section in the terms reference. The role in the
+          story must exactly match one of the named roles.
+
+          Pass when the role matches a defined role from the terms reference.
+          Fail when the role does not match any defined role.
+
+          Context: emit a single line.
+            - "Role '<role>': matches '<terms role name>'"
+            or
+            - "Role '<role>': not found in terms — defined roles are <list>"
+        rationale: "Only roles defined in the terms vocabulary are valid. This ensures human personas and consistent naming."
         docs:
-          - prd
           - terms
-          - architecture_yaml
 
   - id: what
     name: "User Goal"
     description: "The goal - what the user wants to accomplish, not how"
     validation_prompts:
-      - Q: "Does 'I want' describe a goal or a technical solution? A technical solution dictates OUR internal architecture: specific frameworks, database schemas, API designs. NOT technical solutions: (1) Product names users interact with (Google Docs, Gmail); (2) 3rd-party authentication methods users perform (OAuth, service account) - these describe user context, not our implementation. First explain your reasoning, then answer: goal/solution"
-        A: "goal"
+      - Q: |
+          Does the "I want" clause describe a user goal or a technical
+          solution?
+
+          A technical solution dictates OUR internal architecture: specific
+          frameworks, database schemas, API designs.
+
+          NOT technical solutions:
+          (1) Product names users interact with (Google Docs, Gmail)
+          (2) 3rd-party authentication methods users perform (OAuth, service
+              account) — these describe user context, not our implementation
+
+          Examples:
+          - User goal: "I want to edit my documents collaboratively"
+          - Technical solution: "I want a WebSocket-based real-time sync engine"
+
+          Pass when "I want" describes a user goal.
+          Fail when "I want" prescribes a technical solution.
+
+          Context: emit a single line.
+            - "Describes goal — '<short summary>'"
+            or
+            - "Prescribes solution — '<quoted phrase>'"
         rationale: "'Log in with Google account' (goal) vs 'OAuth 2.0 authentication' (solution)."
         docs:
           - prd
           - terms
           - architecture_yaml
 
-      - Q: "Count internal implementation terms in the 'I want' clause. Internal implementation terms are OUR technical decisions: SDK, REST, GraphQL, database, endpoint, WebSocket, JWT, microservice, cache, API (when referring to our API). NOT implementation terms: (1) Product names users interact with (Google Docs, Gmail, Slack); (2) 3rd-party authentication methods users perform (OAuth, service account, API key) - these describe USER actions with external services, not our implementation. First explain your reasoning, then answer as integer."
-        A: "0"
+      - Q: |
+          Count internal implementation terms in the "I want" clause.
+
+          Internal implementation terms are OUR technical decisions: SDK,
+          REST, GraphQL, database, endpoint, WebSocket, JWT, microservice,
+          cache, API (when referring to our API).
+
+          NOT implementation terms:
+          (1) Product names users interact with (Google Docs, Gmail, Slack)
+          (2) 3rd-party authentication methods users perform (OAuth, service
+              account, API key) — these describe USER actions with external
+              services, not our implementation
+
+          Pass when the count is 0.
+          Fail when the count is 1 or more.
+
+          Context: emit one line with the count, then one line per term found.
+            - "Implementation terms in 'I want': <N>"
+            - "<term>: '<quoted phrase in context>'"
         rationale: "User language, not technical language."
         docs:
           - prd
@@ -90,33 +134,87 @@ sections:
     description: "The reason - understanding WHY shapes HOW teams implement"
     source: "https://www.mountaingoatsoftware.com/blog/short-answers-to-your-big-questions-about-user-stories"
     validation_prompts:
-      - Q: "Is the 'so that' clause present? Answer: yes/no"
-        A: "yes"
-        rationale: "Without WHY, teams may implement wrong solution."
-        docs:
-          - prd
-          - terms
-          - architecture_yaml
+      - Q: |
+          Does the "so that" clause describe a user/business benefit
+          (not system behavior)?
 
-      - Q: "Does 'so that' describe user/business benefit (not system behavior)? Answer: yes/no"
-        A: "yes"
+          A user/business benefit explains value to the user or organization
+          (e.g. "save time", "reduce errors", "gain insight").
+          System behavior describes what the system does internally
+          (e.g. "data is stored", "record is created", "cache is updated").
+
+          Pass when "so that" describes a user or business benefit.
+          Fail when "so that" describes system behavior.
+
+          Context: emit a single line.
+            - "Benefit — '<quoted so_that summary>'"
+            or
+            - "System behavior — '<quoted so_that summary>'"
         rationale: "'So that I save time' (benefit) vs 'so that data is stored' (system behavior)."
         docs:
           - prd
           - terms
           - architecture_yaml
 
-      - Q: "Does 'so that' just restate 'I want' in different words? Answer: yes/no"
-        A: "no"
+      - Q: |
+          Does the "so that" clause just restate the "I want" clause in
+          different words?
+
+          Pass when "so that" adds distinct value beyond "I want".
+          Fail when "so that" is a redundant restatement of "I want".
+
+          Context: emit two lines summarizing each clause, then a verdict.
+            - "i_want: '<short summary>'"
+            - "so_that: '<short summary>'"
+            - "Verdict: distinct / redundant"
         rationale: "'Reset password so password is reset' adds no value."
         docs:
           - prd
           - terms
           - architecture_yaml
 
-      - Q: "Would knowing this WHY change implementation approach? Answer: yes/no"
-        A: "yes"
+      - Q: |
+          Would knowing this WHY (the "so that" clause) change the
+          implementation approach?
+
+          A meaningful WHY constrains or informs HOW teams build the
+          feature — it rules out certain approaches or favors others.
+          A trivial WHY could be removed without affecting any
+          implementation decision.
+
+          Pass when the WHY meaningfully informs implementation decisions.
+          Fail when the WHY is too generic to influence implementation.
+
+          Context: emit a line explaining how the WHY shapes implementation.
+            - "WHY informs implementation — '<short explanation>'"
+            or
+            - "WHY too generic — '<short explanation>'"
         rationale: "If WHY doesn't inform HOW, it's not a meaningful benefit clause."
+        docs:
+          - prd
+          - terms
+          - architecture_yaml
+
+      - Q: |
+          Count internal implementation terms in the "so that" clause.
+
+          Internal implementation terms are OUR technical decisions: SDK,
+          REST, GraphQL, database, endpoint, WebSocket, JWT, microservice,
+          cache, API (when referring to our API).
+
+          NOT implementation terms:
+          (1) Product names users interact with (Google Docs, Gmail, Slack)
+          (2) 3rd-party authentication methods users perform (OAuth, service
+              account, API key) — these describe USER actions with external
+              services, not our implementation
+
+          Pass when the count is 0.
+          Fail when the count is 1 or more.
+
+          Context: emit one line with the count, then one line per term found.
+            - "Implementation terms in 'so that': <N>"
+            - "<term>: '<quoted phrase in context>'"
+        rationale: "so_that should describe user value, not technical implementation."
         docs:
           - prd
           - terms


### PR DESCRIPTION
- Replace per-prompt answer formats (yes/no, integer, range, choice) with universal `answer: pass|fail` + `context: []string`
- Drop `A:` field from all rewritten prompts; pass criterion now stated in `Q:` text
- Drop redundant `format.4` (need vs solution) — covered by `what.1` (goal vs solution)
- Drop redundant `why.1` (so_that present) — covered by `format.1` (three clauses check)
- Drop generic `format.3` (implementation terms in whole statement) — replaced by per-clause checks in `what` and `why` sections
- Collapse `who` section from 2 prompts to 1: role must match `terms.yaml` roles reference
- Add new `why` prompt: implementation terms in "so that" clause
- Final: 4 sections, 9 prompts (was 12)

Companion to #132 which did the same migration for `us-refine.yaml`. The existing checklist engine already supports universal pass/fail output — this PR brings `us-create.yaml` into alignment so all checklist commands use the same answer schema.
