### PR TITLE
chore(pr-merge): guard local-branch deletion when gh already removed it

### DIFF
--- a/.claude/skills/pr-merge/SKILL.md
+++ b/.claude/skills/pr-merge/SKILL.md
@@ -13,7 +13,7 @@ Merge the current branch's pull request and clean up afterwards. This is a squas
 2. Run `gh pr merge --squash --delete-branch` to squash-merge and delete the remote branch
 3. Detect whether the main branch is called `main` or `master`
 4. Check out the main branch and pull latest changes
-5. Delete the local feature branch
+5. Delete the local feature branch if it still exists (`gh pr merge --delete-branch` may have already removed it)
 
 ## Implementation
 
@@ -30,10 +30,10 @@ if git show-ref --verify --quiet refs/heads/master; then
 fi
 
 git checkout $MAIN_BRANCH
-git pull origin $MAIN_BRANCH
+git pull origin $MAIN_BRANCH || exit 1
 
-if [ $? -eq 0 ]; then
-    git branch -D $CURRENT_BRANCH
+if git show-ref --verify --quiet "refs/heads/$CURRENT_BRANCH"; then
+    git branch -D "$CURRENT_BRANCH"
 fi
 ```
 


### PR DESCRIPTION
- Replace the post-pull `$? -eq 0` check with an explicit `|| exit 1` on `git pull` so the script halts on a real failure
- Replace unconditional `git branch -D $CURRENT_BRANCH` with a `refs/heads/$CURRENT_BRANCH` guard via `git show-ref` so the cleanup is a no-op when `gh pr merge --delete-branch` already removed the local branch
- Update step 5's description to call out that `gh pr merge --delete-branch` may have already removed the local branch

`gh pr merge --squash --delete-branch` deletes both remote and local feature branches when run from inside the branch being merged. The skill's final `git branch -D` then exits non-zero with `error: branch '<name>' not found`, propagating as the script's overall exit code even though the merge itself fully succeeded. Guarding the cleanup on `git show-ref` removes that spurious failure without relying on `gh`'s behaviour: if anything ever leaves the local branch behind, it still gets cleaned up.
