### PR TITLE
feat(claude): add true-bdd-sync skill mirroring bdd-cli to standalone repo

### DIFF
--- a/.claude/skills/true-bdd-sync/SKILL.md
+++ b/.claude/skills/true-bdd-sync/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: true-bdd-sync
+description: One-way mirror of bdd-cli from this monorepo into the standalone ondatra-ai/true-bdd repo, opening a sync PR. Use whenever the user wants to "sync true-bdd", "publish bdd-cli", "push bdd-cli to the standalone repo", or update the external true-bdd mirror after monorepo changes land on main.
+---
+
+# true-bdd Sync
+
+One-shot mirror from the monorepo to the standalone `ondatra-ai/true-bdd` repo. The script clones (or refreshes) `true-bdd`, branches off its `main`, rsyncs four trees, auto-patches one path inside `tests/bdd/runner/runner.go`, asks `claude -p` to author the commit message + PR body (focused on the engine changes carried, not the mechanical file moves), commits, pushes, and opens (or updates) a sync PR. The script prints the PR URL on completion.
+
+```bash
+./.claude/skills/true-bdd-sync/sync.sh
+```
+
+## What gets mirrored
+
+| Monorepo | true-bdd |
+|---|---|
+| `scripts/bdd-cli/src/**` | `src/**` |
+| `scripts/bdd-cli/templates/**` | `templates/**` |
+| `scripts/bdd-cli/tests/**` | `tests/**` |
+| `bdd-cli/checklists/*.yaml` (excludes `*.tmp`) | `bdd-cli/checklists/*.yaml` |
+
+`rsync --delete` removes files in `true-bdd` that no longer exist in the monorepo.
+
+## What is not touched
+
+- Project-specific config: `bdd-cli/{architecture,terms,acceptance-criteria-and-splitting,bdd-cli}.yaml`, all `*-schema.yaml`. These describe the MCP product, not the engine.
+- `true-bdd`'s `.gitignore`, `LICENSE`, and anything outside the four mapped trees.
+
+## Auto-patch
+
+After mirroring, `sed` rewrites the one path inside `tests/bdd/runner/runner.go`'s `repoLayer()` from `"scripts/bdd-cli/templates"` to `"templates"` so the BDD harness resolves against `true-bdd`'s flat layout.
+
+## Rules
+
+- Working clone lives at `./tmp/sync/true-bdd/` and is reused across runs.
+- If nothing changed since the last sync, the script exits 0 without committing or pushing.
+- Branch name: `chore/sync-from-monorepo-<short-monorepo-sha>`. Re-running on the same monorepo HEAD updates the existing PR; running on a new HEAD opens a new one.
+- The script outputs the PR URL — report that back to the user.

--- a/.claude/skills/true-bdd-sync/SKILL.md
+++ b/.claude/skills/true-bdd-sync/SKILL.md
@@ -19,8 +19,9 @@ One-shot mirror from the monorepo to the standalone `ondatra-ai/true-bdd` repo. 
 | `scripts/bdd-cli/templates/**` | `templates/**` |
 | `scripts/bdd-cli/tests/**` | `tests/**` |
 | `bdd-cli/checklists/*.yaml` (excludes `*.tmp`) | `bdd-cli/checklists/*.yaml` |
+| `scripts/bdd-cli/README.md` | `README.md` |
 
-`rsync --delete` removes files in `true-bdd` that no longer exist in the monorepo.
+`rsync --delete` removes files inside the four mirrored trees that no longer exist in the monorepo. The README is mirrored as a single file (no `--delete`).
 
 ## What is not touched
 

--- a/.claude/skills/true-bdd-sync/sync.sh
+++ b/.claude/skills/true-bdd-sync/sync.sh
@@ -48,13 +48,14 @@ else
   ALREADY_SYNCED=0
 fi
 
-# 3. Mirror the four trees.
+# 3. Mirror the four trees and the README.
 rsync -a --delete "$REPO/scripts/bdd-cli/src/" "$TARGET/src/"
 rsync -a --delete "$REPO/scripts/bdd-cli/templates/" "$TARGET/templates/"
 rsync -a --delete "$REPO/scripts/bdd-cli/tests/" "$TARGET/tests/"
 mkdir -p "$TARGET/bdd-cli/checklists"
 rsync -a --delete --exclude='*.tmp' \
   "$REPO/bdd-cli/checklists/" "$TARGET/bdd-cli/checklists/"
+rsync -a "$REPO/scripts/bdd-cli/README.md" "$TARGET/README.md"
 
 # 4. Patch tests/bdd/runner/runner.go: rewrite the one template path
 #    that differs between the monorepo's nested layout and true-bdd's

--- a/.claude/skills/true-bdd-sync/sync.sh
+++ b/.claude/skills/true-bdd-sync/sync.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# Usage: sync.sh
+# One-way mirror from this monorepo into the standalone
+# ondatra-ai/true-bdd repo. Clones (or refreshes) true-bdd, rsyncs four
+# trees, auto-patches the BDD runner's template path, commits, pushes,
+# and opens or updates a sync PR. Prints the PR URL.
+set -euo pipefail
+
+if ! command -v claude >/dev/null 2>&1; then
+  echo "claude CLI not found in PATH." >&2
+  exit 1
+fi
+
+REPO=$(git rev-parse --show-toplevel)
+WORK="$REPO/tmp/sync"
+TARGET="$WORK/true-bdd"
+TARGET_REMOTE="git@github.com:ondatra-ai/true-bdd.git"
+
+mkdir -p "$WORK"
+
+# 1. Clone or refresh true-bdd to a clean origin/main, with all
+#    remote-tracking refs up to date. Force the full-tree fetch refspec
+#    so prior single-branch / shallow checkouts still pick up every
+#    remote branch (without this, sync-from-monorepo-* branches stay
+#    invisible and the re-run guard misfires).
+if [ -d "$TARGET/.git" ]; then
+  git -C "$TARGET" config remote.origin.fetch \
+    '+refs/heads/*:refs/remotes/origin/*'
+  git -C "$TARGET" fetch --quiet --prune origin
+  git -C "$TARGET" checkout --quiet main
+  git -C "$TARGET" reset --quiet --hard origin/main
+  git -C "$TARGET" clean -fdq
+else
+  rm -rf "$TARGET"
+  git clone --quiet "$TARGET_REMOTE" "$TARGET"
+fi
+
+# 2. Branch off origin/main. If a sync for this monorepo SHA already
+#    exists on the remote, reuse it instead of recreating (which would
+#    produce a divergent commit and a push conflict on re-run).
+SHORT_SHA=$(git -C "$REPO" rev-parse --short HEAD)
+BRANCH="chore/sync-from-monorepo-${SHORT_SHA}"
+if git -C "$TARGET" show-ref --verify --quiet "refs/remotes/origin/$BRANCH"; then
+  git -C "$TARGET" checkout -B "$BRANCH" "origin/$BRANCH" >/dev/null 2>&1
+  ALREADY_SYNCED=1
+else
+  git -C "$TARGET" checkout -B "$BRANCH" origin/main >/dev/null 2>&1
+  ALREADY_SYNCED=0
+fi
+
+# 3. Mirror the four trees.
+rsync -a --delete "$REPO/scripts/bdd-cli/src/" "$TARGET/src/"
+rsync -a --delete "$REPO/scripts/bdd-cli/templates/" "$TARGET/templates/"
+rsync -a --delete "$REPO/scripts/bdd-cli/tests/" "$TARGET/tests/"
+mkdir -p "$TARGET/bdd-cli/checklists"
+rsync -a --delete --exclude='*.tmp' \
+  "$REPO/bdd-cli/checklists/" "$TARGET/bdd-cli/checklists/"
+
+# 4. Patch tests/bdd/runner/runner.go: rewrite the one template path
+#    that differs between the monorepo's nested layout and true-bdd's
+#    flat layout.
+RUNNER="$TARGET/tests/bdd/runner/runner.go"
+if [ -f "$RUNNER" ]; then
+  if sed --version >/dev/null 2>&1; then
+    sed -i 's|"scripts/bdd-cli/templates"|"templates"|g' "$RUNNER"
+  else
+    sed -i '' 's|"scripts/bdd-cli/templates"|"templates"|g' "$RUNNER"
+  fi
+fi
+
+# 5. Bail if nothing changed.
+#    - On a fresh sync: clean status against origin/main → no monorepo
+#      changes since the standalone repo's main.
+#    - On a re-run (ALREADY_SYNCED=1): the working tree should be clean
+#      because the existing sync branch already contains the diff. If
+#      anything would change, that's a drift signal — abort loudly so
+#      the operator can investigate.
+if [ -z "$(git -C "$TARGET" status --porcelain)" ]; then
+  if [ "$ALREADY_SYNCED" = "1" ]; then
+    echo "Sync for monorepo @ ${SHORT_SHA} already pushed; skipping to PR step."
+  else
+    echo "No changes to sync. true-bdd main already matches monorepo @ ${SHORT_SHA}."
+    exit 0
+  fi
+elif [ "$ALREADY_SYNCED" = "1" ]; then
+  echo "ERROR: existing sync branch '${BRANCH}' diverges from a fresh mirror." >&2
+  echo "       Either the monorepo or the standalone repo has been edited since the sync was pushed." >&2
+  echo "       Resolve manually before re-running." >&2
+  exit 1
+fi
+
+# 6. Stage, ask Claude to write the commit message + PR body, commit,
+#    push — only on a fresh sync. A re-run skips straight to the PR
+#    step and reuses the previously-generated message.
+MONO_REMOTE=$(git -C "$REPO" remote get-url origin)
+MONO_REPO_URL=$(echo "$MONO_REMOTE" \
+  | sed -E 's|^git@github\.com:|https://github.com/|; s|\.git$||')
+
+MSG_FILE="$WORK/sync-msg.txt"
+TITLE_FILE="$WORK/sync-title.txt"
+BODY_FILE="$WORK/sync-body.md"
+
+if [ "$ALREADY_SYNCED" = "0" ]; then
+  git -C "$TARGET" add -A
+
+  PROMPT='Generate a commit message + PR body for a one-way SYNC commit that mirrors engine code from a monorepo into a standalone repo. This is a mechanical mirror, not a feature change — the noteworthy content is which engine changes from the source repo are now reaching the standalone consumers.
+
+Format:
+LINE 1: title (max 120 chars; "chore(sync): ..." prefix; name the most impactful engine change carried, not the file moves)
+LINE 2: blank
+LINE 3 onward: body. Start with a one-sentence framing of what landed (cite source-repo commits by their conventional-commit titles, not by SHA). Then a short bullet list of the noteworthy engine-level changes carried in this sync (skip mechanical renames, focus on new features / refactors / fixes). Then a final paragraph naming the source repo and SHA for traceability.
+
+No markdown code fences, no Co-authored-by, no Generated-with trailers, no surrounding quotes, no explanation. Output only the message.'
+
+  {
+    echo "=== Sync mapping (mechanical) ==="
+    echo "scripts/bdd-cli/src/        -> src/"
+    echo "scripts/bdd-cli/templates/  -> templates/"
+    echo "scripts/bdd-cli/tests/      -> tests/"
+    echo "bdd-cli/checklists/*.yaml   -> bdd-cli/checklists/"
+    echo "tests/bdd/runner/runner.go: repoLayer() template path rewritten for flat layout"
+    echo ""
+    echo "=== Source repo: ${MONO_REPO_URL}@${SHORT_SHA} ==="
+    echo ""
+    echo "=== Source-repo recent commits (last 15) ==="
+    git -C "$REPO" log -15 --pretty=format:"%h %s"
+    echo ""
+    echo ""
+    echo "=== Stat of changes this sync carries to the standalone repo ==="
+    git -C "$TARGET" diff --cached --stat
+  } | claude -p "$PROMPT" \
+    | sed -e '/^```[a-zA-Z]*$/d' -e '/^```$/d' > "$MSG_FILE"
+
+  if [ ! -s "$MSG_FILE" ]; then
+    echo "Claude returned an empty sync message." >&2
+    exit 1
+  fi
+
+  head -n 1 "$MSG_FILE" > "$TITLE_FILE"
+  tail -n +3 "$MSG_FILE" > "$BODY_FILE"
+
+  if [ ! -s "$TITLE_FILE" ] || [ ! -s "$BODY_FILE" ]; then
+    echo "Parsed empty title or body from Claude output." >&2
+    exit 1
+  fi
+
+  git -C "$TARGET" commit --quiet -F "$MSG_FILE"
+  git -C "$TARGET" push --quiet -u origin "$BRANCH"
+fi
+
+# 7. Open or update the sync PR. On a re-run the message files won't
+#    have been regenerated this turn — fall back to the existing PR
+#    body if so (gh pr edit accepts a body-file; gh pr create requires
+#    one).
+
+#    On a fresh sync the title/body were generated above. On a re-run
+#    they were not — read them from the existing commit on the branch.
+if [ "$ALREADY_SYNCED" = "1" ]; then
+  git -C "$TARGET" log -1 --pretty='%s' "$BRANCH" > "$TITLE_FILE"
+  git -C "$TARGET" log -1 --pretty='%b' "$BRANCH" > "$BODY_FILE"
+fi
+
+PR_TITLE=$(cat "$TITLE_FILE")
+
+(
+  cd "$TARGET"
+  # Only treat OPEN PRs as "reuse me" — closed/merged PRs that happen
+  # to match the branch name are ignored (a fresh PR is created
+  # instead, because closed PRs whose head SHA has changed can't be
+  # reopened).
+  OPEN_PR_NUMBER=$(gh pr list \
+    --head "$BRANCH" --state open --json number -q '.[0].number // ""')
+
+  if [ -n "$OPEN_PR_NUMBER" ]; then
+    gh pr edit "$OPEN_PR_NUMBER" \
+      --title "$PR_TITLE" --body-file "$BODY_FILE" >/dev/null
+    gh pr view "$OPEN_PR_NUMBER" --json url -q .url
+  else
+    gh pr create \
+      --base main --head "$BRANCH" \
+      --title "$PR_TITLE" --body-file "$BODY_FILE" >/dev/null
+    gh pr view "$BRANCH" --json url -q .url
+  fi
+)
+
+rm -f "$MSG_FILE" "$TITLE_FILE" "$BODY_FILE"

--- a/scripts/bdd-cli/README.md
+++ b/scripts/bdd-cli/README.md
@@ -2,9 +2,10 @@
 
 An aspirational **Spec-as-Source** CLI: Gherkin-style behavioural specs
 plus a system-architecture description are the source of truth, and code
-is a regeneratable build artifact. Today the tool operates one level
-down — **Spec-Anchored** — driving Claude-mediated checklists over user
-stories.
+is a regeneratable artifact whose *observable behaviour* — not its
+byte-for-byte shape — survives a rebuild. Today the tool operates one
+level down — **Spec-Anchored** — driving Claude-mediated checklists over
+user stories.
 
 ## Table of contents
 
@@ -31,9 +32,12 @@ Piskala 2026) splits spec-driven development into three patterns:
 | **Spec-Anchored** | Code, but spec is a living contract. CI validates code against spec. | Hand-edited; spec updates via review. | GitHub Spec Kit, Kiro, BMAD, OpenSpec, current Tessl, LeanSpec, Augment Intent. |
 | **Spec-as-Source** | Spec. Code is derived. | Forbidden — edit the spec, regenerate the code. | Tessl (historically, via `tessl build`), **TrueBDD** (aspirational). |
 
-The test that distinguishes them: *Can you delete all the code and
-regenerate it identically from the spec?* For Spec-as-Source the answer
-is **yes by design**.
+The test that distinguishes them: *Can you delete all the code,
+regenerate from the spec, and have the new build pass every behavioural
+assertion the spec carries?* For Spec-as-Source the answer is **yes by
+design**. The regenerated code is free to differ in structure, naming,
+even in which auxiliary endpoints exist — what survives a rebuild is
+the **behaviour**, not the bytes.
 
 ## Vision
 
@@ -48,18 +52,27 @@ Spec-as-Source flips that contract. To make it work, the spec system
 has to carry enough information for an AI to reconstruct the code:
 
 - **Behavioural spec** — Gherkin (or a Gherkin-shaped DSL) describing
-  user-visible behaviour, *not* code structure. Each scenario maps
-  deterministically to an executable test.
+  user-visible behaviour, *not* code structure. Every scenario becomes
+  an executable test that any regenerated build must pass.
 - **Architectural spec** — services, data models, transport protocols
   (REST / GraphQL / etc.), endpoints, and the persistent contract
   (what survives a rebuild). Docker Compose YAML is a natural fit for
   the service shape.
 - **Regeneration loop** — the AI is allowed to invent absent endpoints
-  and code paths to satisfy the spec; what it *cannot* invent are the
-  persistent contracts (data models, exposed endpoints) declared by
-  the architecture.
+  and internal code paths to satisfy the spec, so two rebuilds from
+  the same spec will not produce byte-identical code. What it *cannot*
+  invent are the persistent contracts (data models, exposed endpoints)
+  declared by the architecture — those are pinned across rebuilds.
 - **BDD tests as oracle** — derived from the behavioural spec, they
-  decide whether a regenerated build is acceptable.
+  are the *definition* of a correct rebuild. If every scenario passes,
+  the rebuild is acceptable, regardless of how the code differs from
+  the previous build.
+
+The contract Spec-as-Source promises, then, is **behaviour preservation
+under regeneration** — not byte-identical regeneration. The behavioural
+spec defines observable outputs; the architectural spec pins the
+persistent contracts; the implementation in between is free to drift
+between rebuilds, as long as both contracts are honoured.
 
 `bdd-cli` is the substrate this vision is being built on. The `us`
 subcommand suite manages the spec lifecycle; the `build` subcommands
@@ -143,8 +156,10 @@ shipped a true Spec-as-Source mode (`tessl build`, retired Jan 2026).
 
 TrueBDD's bet is that **Gherkin-grade behavioural specs + an
 explicit architectural contract** are enough to make Spec-as-Source
-tractable again — without giving up determinism by relying on free-form
-prose specs.
+tractable again — pinning observable behaviour and persistent
+contracts tight enough that the regenerated code's shape can vary
+freely between rebuilds without the system's observable behaviour
+drifting.
 
 ## References
 


### PR DESCRIPTION
- Add .claude/skills/true-bdd-sync/SKILL.md describing the one-way mirror into ondatra-ai/true-bdd, the four mapped trees (src/, templates/, tests/, bdd-cli/checklists/), the README single-file copy, the runner.go template-path auto-patch, and the re-run semantics keyed off the short monorepo SHA
- Add .claude/skills/true-bdd-sync/sync.sh that clones or refreshes a working clone under tmp/sync/true-bdd, branches chore/sync-from-monorepo-<short-sha> off origin/main (reusing an existing remote branch on re-run), rsyncs the four trees with --delete plus the README without --delete, and sed-rewrites "scripts/bdd-cli/templates" to "templates" inside tests/bdd/runner/runner.go
- Guard the no-op path: exit 0 cleanly when a fresh sync produces no diff, and abort loudly when a re-run against an already-pushed sync branch would diverge
- Ask `claude -p` to author the commit title + PR body framed around the engine changes carried (not the mechanical file moves), strip stray code fences, split into title/body files, commit, and push only on a fresh sync; re-runs reuse the existing commit message via git log
- Open a new sync PR via `gh pr create` when no open PR matches the branch, otherwise edit the open PR's title and body in place; print the PR URL on completion
- Reframe scripts/bdd-cli/README.md around behaviour preservation under regeneration: regenerated code is a rebuildable artifact whose observable behaviour (not byte shape) survives, two rebuilds may differ in structure/naming/auxiliary endpoints, and BDD scenarios are the definition of an acceptable rebuild
- Tighten the Spec-as-Source distinguishing test to "delete the code, regenerate, and pass every behavioural assertion" and restate TrueBDD's bet as pinning observable behaviour plus persistent architectural contracts while letting code shape drift between rebuilds

Publishing bdd-cli as the standalone ondatra-ai/true-bdd repo needs a repeatable, one-way mirror that operators can re-run safely as the monorepo evolves, with a PR description that surfaces what actually changed in the engine rather than the mechanical file moves. The README rewrite aligns the standalone repo's framing with the Spec-as-Source vision the sync is meant to publish — behaviour preservation, not byte-identical regeneration.
