### PR TITLE
fix(bdd-cli): thread `-C <dir>` through Go test re-runs and reuse the open sync PR's branch

### DIFF
--- a/.claude/skills/true-bdd-sync/SKILL.md
+++ b/.claude/skills/true-bdd-sync/SKILL.md
@@ -36,5 +36,5 @@ After mirroring, `sed` rewrites the one path inside `tests/bdd/runner/runner.go`
 
 - Working clone lives at `./tmp/sync/true-bdd/` and is reused across runs.
 - If nothing changed since the last sync, the script exits 0 without committing or pushing.
-- Branch name: `chore/sync-from-monorepo-<short-monorepo-sha>`. Re-running on the same monorepo HEAD updates the existing PR; running on a new HEAD opens a new one.
+- Branch selection: if any open sync PR (head ref starting with `chore/sync-from-monorepo`) already exists on the standalone repo, the new sync commit is appended to *that* PR's branch — one PR per review cycle, not one per monorepo SHA. If no open sync PR exists, the script branches off `main` as `chore/sync-from-monorepo` and opens a fresh PR.
 - The script outputs the PR URL — report that back to the user.

--- a/.claude/skills/true-bdd-sync/sync.sh
+++ b/.claude/skills/true-bdd-sync/sync.sh
@@ -35,11 +35,25 @@ else
   git clone --quiet "$TARGET_REMOTE" "$TARGET"
 fi
 
-# 2. Branch off origin/main. If a sync for this monorepo SHA already
-#    exists on the remote, reuse it instead of recreating (which would
-#    produce a divergent commit and a push conflict on re-run).
+# 2. Pick the sync branch. If any open sync PR already exists on the
+#    standalone repo, reuse its head ref so the new commit appends to
+#    that PR (this is how follow-up syncs land on top of an in-review
+#    PR instead of fragmenting into one PR per monorepo SHA). Otherwise
+#    use a stable branch name (no SHA suffix — the SHA lives in the
+#    commit message for traceability, not in the branch name).
 SHORT_SHA=$(git -C "$REPO" rev-parse --short HEAD)
-BRANCH="chore/sync-from-monorepo-${SHORT_SHA}"
+EXISTING_PR_BRANCH=$(
+  cd "$TARGET" && gh pr list \
+    --state open --json headRefName,headRefOid \
+    --search 'head:chore/sync-from-monorepo' \
+    -q '[.[] | select(.headRefName | startswith("chore/sync-from-monorepo"))][0].headRefName // ""'
+)
+if [ -n "$EXISTING_PR_BRANCH" ]; then
+  BRANCH="$EXISTING_PR_BRANCH"
+else
+  BRANCH="chore/sync-from-monorepo"
+fi
+
 if git -C "$TARGET" show-ref --verify --quiet "refs/remotes/origin/$BRANCH"; then
   git -C "$TARGET" checkout -B "$BRANCH" "origin/$BRANCH" >/dev/null 2>&1
   ALREADY_SYNCED=1
@@ -69,25 +83,21 @@ if [ -f "$RUNNER" ]; then
   fi
 fi
 
-# 5. Bail if nothing changed.
-#    - On a fresh sync: clean status against origin/main → no monorepo
-#      changes since the standalone repo's main.
-#    - On a re-run (ALREADY_SYNCED=1): the working tree should be clean
-#      because the existing sync branch already contains the diff. If
-#      anything would change, that's a drift signal — abort loudly so
-#      the operator can investigate.
+# 5. Decide whether to commit. Two outcomes after mirror:
+#    - Clean working tree: the existing sync branch already matches the
+#      current monorepo (or true-bdd main does, on a fresh run). No new
+#      commit; on a re-run we still refresh PR metadata below.
+#    - Dirty working tree: append a new sync commit. On a fresh run this
+#      opens the PR; on a re-run this stacks the new monorepo changes
+#      on top of the in-review PR (which is exactly the goal — one PR
+#      per review cycle, not one PR per monorepo SHA).
 if [ -z "$(git -C "$TARGET" status --porcelain)" ]; then
   if [ "$ALREADY_SYNCED" = "1" ]; then
-    echo "Sync for monorepo @ ${SHORT_SHA} already pushed; skipping to PR step."
+    echo "Sync branch '${BRANCH}' already matches monorepo @ ${SHORT_SHA}; refreshing PR metadata."
   else
     echo "No changes to sync. true-bdd main already matches monorepo @ ${SHORT_SHA}."
     exit 0
   fi
-elif [ "$ALREADY_SYNCED" = "1" ]; then
-  echo "ERROR: existing sync branch '${BRANCH}' diverges from a fresh mirror." >&2
-  echo "       Either the monorepo or the standalone repo has been edited since the sync was pushed." >&2
-  echo "       Resolve manually before re-running." >&2
-  exit 1
 fi
 
 # 6. Stage, ask Claude to write the commit message + PR body, commit,
@@ -101,7 +111,7 @@ MSG_FILE="$WORK/sync-msg.txt"
 TITLE_FILE="$WORK/sync-title.txt"
 BODY_FILE="$WORK/sync-body.md"
 
-if [ "$ALREADY_SYNCED" = "0" ]; then
+if [ -n "$(git -C "$TARGET" status --porcelain)" ]; then
   git -C "$TARGET" add -A
 
   PROMPT='Generate a commit message + PR body for a one-way SYNC commit that mirrors engine code from a monorepo into a standalone repo. This is a mechanical mirror, not a feature change — the noteworthy content is which engine changes from the source repo are now reaching the standalone consumers.
@@ -149,14 +159,11 @@ No markdown code fences, no Co-authored-by, no Generated-with trailers, no surro
   git -C "$TARGET" push --quiet -u origin "$BRANCH"
 fi
 
-# 7. Open or update the sync PR. On a re-run the message files won't
-#    have been regenerated this turn — fall back to the existing PR
-#    body if so (gh pr edit accepts a body-file; gh pr create requires
-#    one).
-
-#    On a fresh sync the title/body were generated above. On a re-run
-#    they were not — read them from the existing commit on the branch.
-if [ "$ALREADY_SYNCED" = "1" ]; then
+# 7. Open or update the sync PR. If section 6 ran a commit, the title
+#    and body files are populated; otherwise (clean re-run) fall back
+#    to the latest commit on the branch so `gh pr edit` still has
+#    something to set.
+if [ ! -s "$TITLE_FILE" ] || [ ! -s "$BODY_FILE" ]; then
   git -C "$TARGET" log -1 --pretty='%s' "$BRANCH" > "$TITLE_FILE"
   git -C "$TARGET" log -1 --pretty='%b' "$BRANCH" > "$BODY_FILE"
 fi

--- a/scripts/bdd-cli/src/internal/infrastructure/testrunner/go_runner.go
+++ b/scripts/bdd-cli/src/internal/infrastructure/testrunner/go_runner.go
@@ -72,9 +72,11 @@ func (r *GoTestRunner) Discover(
 	return failures, nil
 }
 
-// RunOne re-executes a single failing Go test by its TestName id. For
-// build-failure synthetic entries (TestName suffix `::<build>`) it
-// instead re-runs the whole package and looks for any remaining failure.
+// RunOne re-executes a single failing Go test by its TestName id, in
+// the same module root Discover used (threaded through as `-C
+// failingTest.RunnerConfig.Path`). For build-failure synthetic entries
+// (TestName suffix `::<build>`) it instead re-runs the whole package
+// and looks for any remaining failure.
 func (r *GoTestRunner) RunOne(
 	ctx context.Context,
 	failingTest *FailingTest,
@@ -84,7 +86,7 @@ func (r *GoTestRunner) RunOne(
 		return false, "", err
 	}
 
-	args := buildGoRunOneArgs(pkg, test)
+	args := buildGoRunOneArgs(failingTest.RunnerConfig.Path, pkg, test)
 
 	stdout, stderr, runErr := r.exec(ctx, args...)
 	if runErr != nil && stdout.Len() == 0 {
@@ -127,16 +129,20 @@ func (r *GoTestRunner) exec(
 }
 
 // buildGoRunOneArgs assembles the `go test` invocation for re-running a
-// single test. Build-failure synthetic entries use no `-run` filter so
-// the package's compile is the verdict.
-func buildGoRunOneArgs(pkg, test string) []string {
+// single test. The dir is threaded through as `-C <dir>` to match the
+// module/cwd used by Discover — in a multi-module repo (each service
+// with its own go.mod), running from the wrong root would silently fail
+// to resolve the package and the fix loop would never converge.
+// Build-failure synthetic entries use no `-run` filter so the package's
+// compile is the verdict.
+func buildGoRunOneArgs(dir, pkg, test string) []string {
 	if test == goBuildFailureMarker {
-		return []string{"-json", "-count=1", pkg}
+		return []string{"-C", dir, "-json", "-count=1", pkg}
 	}
 
 	runFilter := buildGoRunFilter(test)
 
-	return []string{"-json", "-count=1", "-run", runFilter, pkg}
+	return []string{"-C", dir, "-json", "-count=1", "-run", runFilter, pkg}
 }
 
 // buildGoRunFilter assembles the `-run` regex for one (possibly nested)


### PR DESCRIPTION
- Pass `failingTest.RunnerConfig.Path` into `buildGoRunOneArgs` so `GoTestRunner.RunOne` invokes `go test -C <dir>` against the same module root `Discover` used, fixing silent package-resolution failures in multi-module repos
- Reuse the same `-C <dir>` for build-failure synthetic entries so the package's compile verdict also runs in the right module root
- Replace the per-SHA `chore/sync-from-monorepo-<short-sha>` branch with a stable `chore/sync-from-monorepo` branch and reuse the open sync PR's head ref when one exists, so follow-up syncs append to the in-review PR instead of fragmenting one PR per monorepo SHA
- Query the open sync PR via `gh pr list --search 'head:chore/sync-from-monorepo'` filtered to head refs starting with that prefix
- Rework section 5's clean/dirty branching: clean re-run refreshes PR metadata instead of erroring on "divergence"; dirty tree always stacks a new commit
- Drive section 6's commit gate off `git status --porcelain` so a re-run with new monorepo changes still generates a fresh commit message and pushes
- Switch section 7's title/body fallback to test for empty message files (`[ ! -s ]`) so `gh pr edit` always has populated inputs
- Update `SKILL.md`'s branch-naming bullet to document the one-PR-per-review-cycle model

The Go runner fix unblocks the `build tests --fix` loop in multi-module repos (e.g. true-bdd), where `go test` without `-C` silently fails to resolve packages and the loop never converges. The sync-script changes consolidate follow-up monorepo syncs into a single in-review PR per review cycle instead of fragmenting into one PR per monorepo SHA, matching how the standalone repo's reviewers actually want to consume updates.
