### PR TITLE
fix(bdd-cli): sanitize subject ids in tmp artifact filenames and forbid sub-agent tools in single-turn modes

### DIFF
--- a/scripts/bdd-cli/src/adapters/ai/execution_mode.go
+++ b/scripts/bdd-cli/src/adapters/ai/execution_mode.go
@@ -33,6 +33,12 @@ func (f *ModeFactory) GetThinkMode() ExecutionMode {
 			"Bash",
 			"Edit(**)",
 			"MultiEdit(**)",
+			// Sub-agent tools. Every prompt here is a single-turn
+			// `claude -p` call; delegating to a sub-agent and awaiting it
+			// ends the turn with no output (the parent cannot resume),
+			// which silently yields an empty fix prompt. Force inline work.
+			"Agent",
+			"Task",
 		},
 	}
 }
@@ -57,6 +63,10 @@ func (f *ModeFactory) GetEditMode() ExecutionMode {
 		},
 		[]string{
 			"Bash",
+			// See GetThinkMode: sub-agent delegation breaks single-turn
+			// `claude -p` calls, so keep it disallowed here too.
+			"Agent",
+			"Task",
 		},
 	}
 }

--- a/scripts/bdd-cli/src/internal/app/generators/validate/checklist_evaluator.go
+++ b/scripts/bdd-cli/src/internal/app/generators/validate/checklist_evaluator.go
@@ -116,9 +116,9 @@ func (e *ChecklistEvaluator) evaluatePrompt(
 
 	// Build result file path for FILE_START/FILE_END pattern
 	sectionPath := promptCtx.GetFullSectionPath()
-	safeSectionPath := strings.ReplaceAll(sectionPath, "/", "-")
+	safeSectionPath := sanitizeID(sectionPath)
 	resultPath := fmt.Sprintf("%s/%02d-%s-checklist-%s-result.yaml",
-		e.tmpDir, promptIndex, e.subjectID, safeSectionPath)
+		e.tmpDir, promptIndex, sanitizeID(e.subjectID), safeSectionPath)
 
 	// Load system prompt template (uses cached loader)
 	systemPrompt, err := e.systemLoader.LoadTemplate(ChecklistPromptData{})
@@ -319,9 +319,10 @@ func (e *ChecklistEvaluator) savePromptFile(sectionPath string, promptIndex int,
 		return
 	}
 
-	// Replace slashes in section path with dashes for filename
-	safeSectionPath := strings.ReplaceAll(sectionPath, "/", "-")
-	filePath := fmt.Sprintf("%s/%02d-%s-checklist-%s-%s.txt", e.tmpDir, promptIndex, e.subjectID, safeSectionPath, suffix)
+	// Flatten section path and subject id into safe filename segments.
+	safeSectionPath := sanitizeID(sectionPath)
+	filePath := fmt.Sprintf("%s/%02d-%s-checklist-%s-%s.txt",
+		e.tmpDir, promptIndex, sanitizeID(e.subjectID), safeSectionPath, suffix)
 
 	err := os.WriteFile(filePath, []byte(content), filePermissions)
 	if err != nil {

--- a/scripts/bdd-cli/src/internal/app/generators/validate/fix_applier.go
+++ b/scripts/bdd-cli/src/internal/app/generators/validate/fix_applier.go
@@ -87,7 +87,7 @@ func (a *FixApplier) Apply(
 		"iteration", iteration,
 	)
 
-	resultPath := fmt.Sprintf("%s/apply-%s-iter%d-result.yaml", tmpDir, subjectID, iteration)
+	resultPath := fmt.Sprintf("%s/apply-%s-iter%d-result.yaml", tmpDir, sanitizeID(subjectID), iteration)
 
 	promptData := FixApplierData{
 		Subject:    subject,
@@ -154,7 +154,7 @@ func (a *FixApplier) savePromptFile(storyID string, iteration int, suffix, conte
 		return
 	}
 
-	filePath := fmt.Sprintf("%s/apply-%s-iter%d-%s.txt", a.tmpDir, storyID, iteration, suffix)
+	filePath := fmt.Sprintf("%s/apply-%s-iter%d-%s.txt", a.tmpDir, sanitizeID(storyID), iteration, suffix)
 
 	err := os.WriteFile(filePath, []byte(content), fixApplierFilePermissions)
 	if err != nil {

--- a/scripts/bdd-cli/src/internal/app/generators/validate/fix_prompt_generator.go
+++ b/scripts/bdd-cli/src/internal/app/generators/validate/fix_prompt_generator.go
@@ -92,7 +92,7 @@ func (g *FixPromptGenerator) Generate(
 
 	g.logGenerationStart(params, promptIndex, iteration)
 
-	resultPath := fmt.Sprintf("%s/%02d-%s-fix-prompts.md", params.TmpDir, promptIndex, params.SubjectID)
+	resultPath := fmt.Sprintf("%s/%02d-%s-fix-prompts.md", params.TmpDir, promptIndex, sanitizeID(params.SubjectID))
 	promptData := g.buildPromptData(params, resultPath, iteration)
 
 	response, err := g.executeAIGeneration(ctx, params, promptData, promptIndex, iteration)
@@ -221,7 +221,7 @@ func (g *FixPromptGenerator) savePromptFile(tmpDir, storyID string, promptIndex 
 	}
 
 	// Follow naming convention: XX-<storyID>-<suffix>.txt
-	filePath := fmt.Sprintf("%s/%02d-%s-%s.txt", tmpDir, promptIndex, storyID, suffix)
+	filePath := fmt.Sprintf("%s/%02d-%s-%s.txt", tmpDir, promptIndex, sanitizeID(storyID), suffix)
 
 	err := os.WriteFile(filePath, []byte(content), fixPromptFilePermissions)
 	if err != nil {

--- a/scripts/bdd-cli/src/internal/app/generators/validate/id_sanitizer.go
+++ b/scripts/bdd-cli/src/internal/app/generators/validate/id_sanitizer.go
@@ -1,0 +1,19 @@
+package validate
+
+import "regexp"
+
+// idSanitizerUnsafe matches every run of characters that must not appear
+// in a path segment used for a per-run tmp artifact filename.
+var idSanitizerUnsafe = regexp.MustCompile(`[^A-Za-z0-9._-]+`)
+
+// sanitizeID flattens a subject or section identifier into a single
+// filesystem-safe path segment. Build-code subject ids look like
+// "frontend/integration/playwright:<startup>" — the slashes would spawn
+// uncreated nested dirs and the ":" / "<>" are invalid on some
+// filesystems, so os.WriteFile fails and the debug artifact (and its tmp
+// result file) is silently lost. Collapsing every unsafe run to a single
+// "-" keeps ids like "INT-900" or "4.1" untouched while making the
+// build-code ids writable.
+func sanitizeID(id string) string {
+	return idSanitizerUnsafe.ReplaceAllString(id, "-")
+}


### PR DESCRIPTION
- Add `sanitizeID` in `id_sanitizer.go` that collapses every run of characters outside `[A-Za-z0-9._-]` into a single dash, so build-code subject ids like `frontend/integration/playwright:<startup>` become writable filename segments while ids like `INT-900` or `4.1` pass through untouched
- Apply `sanitizeID` to the subject id and section path in `ChecklistEvaluator`'s result and prompt file paths, replacing the previous slash-only replacement that still left `:` and `<>` in filenames
- Apply `sanitizeID` to the subject/story id in `FixApplier`'s result and prompt file paths, whose slashes previously pointed `os.WriteFile` at uncreated nested dirs and silently dropped the artifacts
- Apply `sanitizeID` to the subject/story id in `FixPromptGenerator`'s result and prompt file paths for the same reason
- Add `Agent` and `Task` to the disallowed tools of both think and edit execution modes, since each prompt is a single-turn `claude -p` call and delegating to a sub-agent ends the turn with no output the parent can resume

The `build code` command produces subject ids containing `/`, `:`, and `<>` (e.g. `frontend/integration/playwright:<startup>`), which broke the tmp artifact file paths used for debugging and result exchange — `os.WriteFile` silently failed on the uncreated nested directories, losing the artifacts entirely. Sanitizing every id at the filename boundary fixes this for all current and future id shapes. Separately, the single-turn `claude -p` execution modes could silently produce empty fix prompts when the model delegated work to a sub-agent, so those tools are now explicitly disallowed.
