### PR TITLE
feat(claude): add update-bdd-cli-readme skill and sync the bdd-cli README with the shipped build commands

### DIFF
--- a/.claude/skills/pr-commit/SKILL.md
+++ b/.claude/skills/pr-commit/SKILL.md
@@ -7,5 +7,6 @@ description: Run quality gates, update memory, commit and push, and update the P
 
 1. Run `./.claude/skills/pr-commit/gates.sh` (lint + test + pre-commit).
 2. Invoke the `update-memory` skill.
-3. Run `./.claude/skills/pr-commit/commit.sh`.
-4. Invoke the `pr-update` skill.
+3. Invoke the `update-bdd-cli-readme` skill.
+4. Run `./.claude/skills/pr-commit/commit.sh`.
+5. Invoke the `pr-update` skill.

--- a/.claude/skills/update-bdd-cli-readme/SKILL.md
+++ b/.claude/skills/update-bdd-cli-readme/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: update-bdd-cli-readme
+description: >
+  Reviews staged changes and updates scripts/bdd-cli/README.md to keep it
+  accurate — especially when CLI commands, flags, checklists, or the BDD
+  fixture manifest change. Called automatically by pr-commit before
+  committing. Can also be invoked manually via "update bdd-cli readme" or
+  "sync the bdd-cli readme".
+---
+
+# Update bdd-cli README
+
+You review the current staged changes (or recent diff) and update
+`scripts/bdd-cli/README.md` to keep it accurate. This runs before every
+commit so the README stays in sync with the tool it documents.
+
+## Scope gate
+
+Only act when the staged diff touches `scripts/bdd-cli/` or `bdd-cli/`
+(the config/data directory at the repo root). If neither is touched — do
+nothing, don't read further.
+
+## What to check
+
+Read the staged diff (`git diff --cached`) and compare against the README
+sections:
+
+### Commands (highest priority)
+
+The `Status` table and `Usage` examples must match the real cobra command
+tree in `scripts/bdd-cli/src/cmd/`:
+
+- New, renamed, or removed subcommands → update the `Status` table, the
+  `Usage` code block, and the Vision paragraph that names the subcommand
+  suites
+- New, renamed, or removed flags (`--fix`, `--requirements`,
+  `--architecture`, …) → update the paragraph under the `Status` table
+- Changed command semantics (what a command reads, writes, or refuses to
+  touch) → update that command's row in the `Status` table
+- A stub becoming working (or a command being gutted back to a stub) →
+  update its `State` cell
+
+### Checklists and configuration
+
+- New or renamed checklist files in `bdd-cli/checklists/` → the
+  `Configuration` section's naming-convention examples
+- Changes to what `bdd-cli.yaml` or `architecture.yaml` configure → the
+  `Configuration` section
+
+### Testing harness
+
+- Changes to the fixture manifest schema in
+  `scripts/bdd-cli/tests/bdd/runner/fixture_manifest.go` (new keys like
+  `prep`/`teardown`, changed assertion strategies) → the `Testing`
+  section
+- Changes to how the runner prepares the tmpdir, snapshots, or judges →
+  the `Testing` section
+- Changed test invocations (build tags, paths) → the `Testing` code block
+
+### Install / prerequisites
+
+- Go version bumps in `scripts/bdd-cli/go.mod`, new external binaries
+  required → the `Install` section
+
+## How to update
+
+1. Read the staged diff
+2. Read the current `scripts/bdd-cli/README.md`
+3. For each section above, check if the diff makes it stale
+4. If yes — edit the README with the minimal change needed
+5. If no changes needed — do nothing, don't touch the file
+6. Stage the README if it was modified
+   (`git add scripts/bdd-cli/README.md`)
+
+## Rules
+
+- **Minimal changes only** — don't reorganize or rewrite sections that
+  weren't affected by the diff
+- **Leave the essay sections alone** — `Background`, `Vision`,
+  `How it compares`, and `References` express direction, not code state;
+  only touch them when a command they name by backtick changes
+- **Both-repo links only** — the README is mirrored verbatim into the
+  standalone `ondatra-ai/true-bdd` repo (see the `true-bdd-sync` skill).
+  Relative links must resolve in both layouts, which means they may only
+  target paths inside `scripts/bdd-cli/` (mirrored to the repo root) such
+  as `templates/`. Never link into monorepo-only paths like `docs/` or
+  `services/`; name them in prose instead
+- **Don't add speculative content** — only document what's actually in
+  the code now
+- **Keep the same style** — match the existing formatting, tone, and
+  level of detail
+- **No commit messages or changelogs** — the README describes the current
+  state, not the history

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,7 +189,7 @@ Each checklist lives in `bdd-cli/checklists/<command>.yaml`. The loader hyphenat
 - `services/backend/` — Go backend (Fiber). Lint: `make lint-backend`.
 - `services/frontend/` — Next.js 16 + React 19 frontend. Lint config is **ESLint 9 flat config** in `services/frontend/eslint.config.mjs`; the rule set committed at `services/frontend/.eslintrc.json` is still authoritative and must not be changed without permission.
 - `scripts/bdd-cli/` — Go source for the bdd-cli tool. Entry point `src/main.go`, module name `bdd-cli`, builds to `./scripts/bdd-cli/bdd-cli`.
-- `bdd-cli/` — bdd-cli **configuration and data** (not source): `bdd-cli.yaml`, `checklists/us-{create,refine,apply}.yaml` and `checklists/build-tests.yaml`, schemas (`*-schema.yaml`), `architecture.yaml`, `terms.yaml`.
+- `bdd-cli/` — bdd-cli **configuration and data** (not source): `bdd-cli.yaml`, `checklists/us-{create,refine,apply}.yaml` and `checklists/build-{tests,code}.yaml`, schemas (`*-schema.yaml`), `architecture.yaml`, `terms.yaml`.
 - `docs/` — `architecture.md`, `prd.md`, `requirements.yaml` (the scenario registry that `us apply` writes to), `epics/`, `stories/`, `qa/`.
 - `tests/` — Playwright INT + E2E tests for the MCP product.
 - `tmp/` — runtime working dir for bdd-cli prompt/response artifacts.

--- a/scripts/bdd-cli/README.md
+++ b/scripts/bdd-cli/README.md
@@ -123,13 +123,27 @@ env -u CLAUDECODE ./bdd-cli build code  --fix
 
 ## Configuration
 
-The host project supplies a `bdd-cli/` directory at its root holding
-`bdd-cli.yaml` (engine type, filesystem paths, prompt-template paths,
-and the documents the checklists are allowed to cite — PRD,
-architecture, coding standards, glossary), one checklist per command
-under `checklists/` (`us create` → `us-create.yaml`, `build tests` →
-`build-tests.yaml`, …), and the `architecture.yaml` that scopes
-`build code`.
+The host project supplies a `bdd-cli/` directory at its root:
+
+- `bdd-cli.yaml` — the engine type, filesystem paths (epics, stories,
+  checklists, tmp), per-command prompt-template paths, and a
+  `documents:` map naming the files a check may cite (PRD,
+  architecture docs, coding standards, BDD guidelines, terms
+  vocabulary). Each check in a checklist lists the document keys it
+  needs under `docs:`, and the engine embeds those files into the
+  prompt.
+- `checklists/` — one checklist per command, named by hyphenating the
+  command path (`us create` → `us-create.yaml`, `build tests` →
+  `build-tests.yaml`, …).
+- `architecture.yaml` — the architectural spec that scopes
+  `build code`: which `(service, layer)` pairs get walked.
+- `terms.yaml` — the domain vocabulary (user roles, allowed action
+  verbs, forbidden qualifiers) that checks cite via the `terms`
+  document key.
+- `*-schema.yaml` — Yamale schemas pinning the shape of the spec
+  artifacts (stories, epics, the requirements registry, checklists,
+  `architecture.yaml`); the host project validates them in its lint
+  step, outside the engine itself.
 
 Prompt templates live in [`templates/`](templates/) (Go `text/template`
 with sprig).

--- a/scripts/bdd-cli/README.md
+++ b/scripts/bdd-cli/README.md
@@ -76,7 +76,9 @@ between rebuilds, as long as both contracts are honoured.
 
 `bdd-cli` is the substrate this vision is being built on. The `us`
 subcommand suite manages the spec lifecycle; the `build` subcommands
-(currently stubs) are where regeneration will live.
+implement the regeneration loop — `build tests` derives executable
+tests from the registry, `build code` regenerates production code
+until those tests pass.
 
 ## Status
 
@@ -85,12 +87,14 @@ subcommand suite manages the spec lifecycle; the `build` subcommands
 | `us create <id>` | **Working** — extracts a story from its epic, validates against the `us-create` checklist, writes to `docs/stories/`. |
 | `us refine <id>` | **Working** — iterates a story against the `us-refine` checklist; updates in place. |
 | `us apply <id>` | **Working** — walks every AC in a refined story, validates against `us-apply`, and merges scenarios into a central `requirements.yaml` registry. |
-| `build tests` | **Stub** — will generate executable tests from the Gherkin scenarios in the registry. |
-| `build code` | **Stub** — will regenerate code from the registry plus the architectural spec. This is the Spec-as-Source step. |
+| `build tests` | **Working** — walks every scenario in the registry against the `build-tests` checklist and exits non-zero if any scenario lacks an executable test. With `--fix`, failed cells drive a Claude-mediated authoring loop that writes the missing test referencing the scenario id; the registry itself is never modified. |
+| `build code` | **Working** — walks every `(service, layer)` pair declared in the architectural spec (`architecture.yaml`), discovers currently-failing tests via each framework's runner, and exits non-zero if any remain. With `--fix`, each failure drives a Claude-mediated turn that edits production source until the test passes; test files and the registry are never modified. This is the Spec-as-Source step. |
 
-All `us` commands accept `--fix` for an interactive loop in which
-Claude proposes edits for each failed check and the user accepts,
-refines, or exits.
+Every command accepts `--fix` for an interactive loop in which
+Claude proposes edits for each failed check and the user applies,
+refines, or exits. `build tests` also takes `--requirements <path>`
+and `build code` takes `--architecture <path>` to override the
+default spec locations.
 
 ## Install
 
@@ -110,6 +114,8 @@ clean environment:
 env -u CLAUDECODE ./bdd-cli us create 4.1
 env -u CLAUDECODE ./bdd-cli us refine 4.1 --fix
 env -u CLAUDECODE ./bdd-cli us apply  4.1 --fix
+env -u CLAUDECODE ./bdd-cli build tests --fix
+env -u CLAUDECODE ./bdd-cli build code  --fix
 ```
 
 `us refine` issues many sequential Claude calls and typically takes
@@ -117,11 +123,13 @@ env -u CLAUDECODE ./bdd-cli us apply  4.1 --fix
 
 ## Configuration
 
-The host project supplies a `bdd-cli.yaml` that pins the engine type,
-filesystem paths, prompt-template paths, and the documents the
-checklists are allowed to cite (PRD, architecture, coding standards,
-glossary). See the worked example at
-[`tests/bdd/fixtures/us-create-happy-path/input/bdd-cli/bdd-cli.yaml`](tests/bdd/fixtures/us-create-happy-path/input/bdd-cli/bdd-cli.yaml).
+The host project supplies a `bdd-cli/` directory at its root holding
+`bdd-cli.yaml` (engine type, filesystem paths, prompt-template paths,
+and the documents the checklists are allowed to cite — PRD,
+architecture, coding standards, glossary), one checklist per command
+under `checklists/` (`us create` → `us-create.yaml`, `build tests` →
+`build-tests.yaml`, …), and the `architecture.yaml` that scopes
+`build code`.
 
 Prompt templates live in [`templates/`](templates/) (Go `text/template`
 with sprig).
@@ -138,13 +146,18 @@ go test -tags bdd ./tests/bdd/...
 
 Fixtures under `tests/bdd/fixtures/<scenario>/` are folders containing
 a `fixture.yaml` manifest and the referenced input directory tree
-(conventionally `input/`). The manifest declares `cmd`, `input`,
-optional `answers` (stdin for `--fix` runs), and an `expected:`
-sub-block with the assertion strategies (`exit_code`, `stdout_regex`,
-`judge`). The runner builds the CLI, copies the input tree into a
-tmpdir, executes `cmd`, and asks Claude to score the resulting diff
-against the `judge:` rubric. The whole suite skips if `claude` is not
-on `$PATH`.
+(conventionally `input/`, holding only designed `docs/` content). The
+manifest declares `cmd`, `input`, optional `answers` (stdin for
+`--fix` runs), optional `prep` (shell commands run in the tmpdir
+before the pre-run snapshot, e.g. `npm install`), optional `teardown`
+(best-effort cleanup run after the post-run snapshot, e.g. stopping a
+compose stack), and an `expected:` sub-block with the assertion
+strategies (`exit_code`, `stdout_regex`, `judge`). The runner builds
+the CLI, pre-populates a tmpdir with the live engine ingredients
+(checklists and prompt templates), overlays the fixture's input tree,
+snapshots, executes `cmd`, and asks Claude to score the resulting
+diff against the `judge:` rubric. The whole suite skips if `claude`
+is not on `$PATH`.
 
 ## How it compares
 


### PR DESCRIPTION
- Add `.claude/skills/update-bdd-cli-readme/SKILL.md`, a skill that reviews the staged diff and updates `scripts/bdd-cli/README.md` whenever `scripts/bdd-cli/` or `bdd-cli/` change, covering commands/flags, checklists, the fixture manifest, and install prerequisites, with rules to keep edits minimal and links resolvable in the mirrored true-bdd repo
- Wire the new skill into the pr-commit checklist as step 3, between update-memory and commit.sh
- Update the README Status table to mark `build tests` and `build code` as Working, describing their registry/architecture walks, `--fix` loops, and what each run refuses to modify
- Document the `--requirements` and `--architecture` overrides, note that every command (not just `us`) accepts `--fix`, and extend the Usage examples with `build tests --fix` and `build code --fix` invocations
- Rewrite the README Configuration section from a single prose paragraph into a per-file itemization of the host `bdd-cli/` directory: `bdd-cli.yaml` (engine type, paths, prompt templates, the `documents:` map cited via `docs:` keys), the hyphenated per-command `checklists/`, the `architecture.yaml` that scopes `build code` to `(service, layer)` pairs, the `terms.yaml` vocabulary, and the `*-schema.yaml` Yamale schemas
- Expand the Testing section with the optional `prep` and `teardown` manifest keys and the runner's pre-populate/overlay/snapshot tmpdir flow
- Update the Vision paragraph now that the `build` subcommands implement the regeneration loop instead of being stubs
- Update the CLAUDE.md project-structure entry for `bdd-cli/` to list `checklists/build-{tests,code}.yaml` now that `build-code.yaml` exists alongside `build-tests.yaml`

The bdd-cli README had drifted behind the shipped tool — `build tests` and `build code` were still documented as stubs, and the Configuration and Testing sections predated the `bdd-cli/` config directory and the `prep`/`teardown` manifest keys. This PR brings the README back in sync and adds a pr-commit-integrated skill so the same drift is caught automatically before every future commit.
